### PR TITLE
Make it so the timeout reader is better about the first read

### DIFF
--- a/util/server/handlers_internal_test.go
+++ b/util/server/handlers_internal_test.go
@@ -1,12 +1,11 @@
 package server
 
 import (
+	"io"
 	"testing"
 	"time"
-	"io"
 )
 
-	
 func TestTimeoutReader(t *testing.T) {
 	// create a new timeout reader
 	timoutReader = &TimeoutReader{
@@ -21,7 +20,7 @@ func TestTimeoutReader(t *testing.T) {
 	if n != 2 || err != nil || string(bytes[:n]) != "1\n" {
 		t.Errorf("the reader didnt output the right data n %d, err %+v, data %q", n, err, bytes)
 	}
-	
+
 	timoutReader.Files <- "123"
 	n, err = timoutReader.Read(bytes)
 	if n != 4 || err != nil || string(bytes[:n]) != "123\n" {

--- a/util/server/handlers_internal_test.go
+++ b/util/server/handlers_internal_test.go
@@ -8,28 +8,28 @@ import (
 
 func TestTimeoutReader(t *testing.T) {
 	// create a new timeout reader
-	timoutReader = &TimeoutReader{
+	timeoutReader = &TimeoutReader{
 		Files:   make(chan string, 1),
 		timeout: time.Second,
 	}
 
 	bytes := make([]byte, 4)
 
-	timoutReader.Files <- "1"
-	n, err := timoutReader.Read(bytes)
+	timeoutReader.Files <- "1"
+	n, err := timeoutReader.Read(bytes)
 	if n != 2 || err != nil || string(bytes[:n]) != "1\n" {
 		t.Errorf("the reader didnt output the right data n %d, err %+v, data %q", n, err, bytes)
 	}
 
-	timoutReader.Files <- "123"
-	n, err = timoutReader.Read(bytes)
+	timeoutReader.Files <- "123"
+	n, err = timeoutReader.Read(bytes)
 	if n != 4 || err != nil || string(bytes[:n]) != "123\n" {
 		t.Errorf("the reader didnt output the right data n %d, err %+v, data %q", n, err, bytes)
 	}
 
 	// now attempt a read without writing
 	// should timeout
-	n, err = timoutReader.Read(bytes)
+	n, err = timeoutReader.Read(bytes)
 	if n != 0 || err != io.EOF {
 		t.Errorf("the timeout reader didnt timeout")
 	}


### PR DESCRIPTION
the http Library calls read the first time on the body with a
[]byte of size 1 just to see if anything is in the reader
this caused the timeout reader to just return the first character
and drop the rest of the filename. Not idea.
So instead anytime a read is called and we cant copy everything
to the calling byte slice we will store the leftovers and
give them to the the next read caller.