### PR TITLE
implementing zero-config-devmode as found in issue #124; added an add…

### DIFF
--- a/commands/dev.go
+++ b/commands/dev.go
@@ -3,6 +3,7 @@ package commands
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/nanobox-io/nanobox-golang-stylish"
 	"github.com/spf13/cobra"
@@ -26,14 +27,17 @@ var (
 	}
 
 	//
-	rebuild bool // force a deploy
-	nobuild bool // force skip a deploy
+	devconfig string // sets the type of environment to be configured on the guest vm
+	nobuild   bool   // force skip a deploy
+	rebuild   bool   // force a deploy
 )
 
 //
 func init() {
-	devCmd.Flags().BoolVarP(&rebuild, "rebuild", "", false, "Force a rebuild")
+	devCmd.Flags().StringVarP(&devconfig, "dev-config", "", config.Nanofile.DevConfig, "The environment to configure on the guest vm")
 	devCmd.Flags().BoolVarP(&nobuild, "no-build", "", false, "Force skip a rebuild")
+	devCmd.Flags().BoolVarP(&rebuild, "rebuild", "", false, "Force a rebuild")
+
 }
 
 // dev
@@ -81,8 +85,13 @@ func dev(ccmd *cobra.Command, args []string) {
 		}
 	}
 
+	v := url.Values{}
+
 	//
-	if err := server.Exec("develop", ""); err != nil {
+	v.Add("dev_config", devconfig)
+
+	//
+	if err := server.Exec("develop", v.Encode()); err != nil {
 		server.Error("[commands/dev] Server.Exec failed", err.Error())
 	}
 

--- a/commands/dev.go
+++ b/commands/dev.go
@@ -4,6 +4,7 @@ package commands
 import (
 	"fmt"
 	"net/url"
+	"os"
 
 	"github.com/nanobox-io/nanobox-golang-stylish"
 	"github.com/spf13/cobra"
@@ -44,6 +45,13 @@ func init() {
 func dev(ccmd *cobra.Command, args []string) {
 
 	// PreRun: boot
+
+	// check to see if the devconfig option is one of our predetermined values. If
+	// not indicate as much and return
+	if _, ok := map[string]int{"mount": 1, "copy": 1, "none": 1}[devconfig]; !ok {
+		fmt.Printf(`--dev-config option "%s" is not accepted. Please choose either "mount", "copy", or "none"\n`, devconfig)
+		os.Exit(1)
+	}
 
 	// don't rebuild
 	if !nobuild {

--- a/config/nanofile.go
+++ b/config/nanofile.go
@@ -14,16 +14,17 @@ import (
 
 // NanofileConfig represents all available/expected .nanofile configurable options
 type NanofileConfig struct {
-	CPUCap   int    `json:"cpu_cap"`   // max %CPU usage allowed to the guest vm
-	CPUs     int    `json:"cpus"`      // number of CPUs to dedicate to the guest vm
-	Domain   string `json:"domain"`    // the domain to use in conjuntion with the ip when accesing the guest vm (defaults to <Name>.dev)
-	IP       string `json:"ip"`        // the ip added to the /etc/hosts file for accessing the guest vm
-	MountNFS bool   `json:"mount_nfs"` // does the code directory get mounted as NFS
-	Name     string `json:"name"`      // the name given to the project (defaults to cwd)
-	Provider string `json:"provider"`  // guest vm provider (virtual box, vmware, etc)
-	RAM      int    `json:"ram"`       // ammount of RAM to dedicate to the guest vm
-	HostDNS  string `json:"host_dns"`  // use the hosts dns resolver
-	SshPath  string `json:"ssh_path"`  // provide the path to the .ssh directory (if any)
+	CPUCap    int    `json:"cpu_cap"`    // max %CPU usage allowed to the guest vm
+	CPUs      int    `json:"cpus"`       // number of CPUs to dedicate to the guest vm
+	DevConfig string `json:"dev_config"` // the type of dev environment to configure on the guest vm
+	Domain    string `json:"domain"`     // the domain to use in conjuntion with the ip when accesing the guest vm (defaults to <Name>.dev)
+	IP        string `json:"ip"`         // the ip added to the /etc/hosts file for accessing the guest vm
+	MountNFS  bool   `json:"mount_nfs"`  // does the code directory get mounted as NFS
+	Name      string `json:"name"`       // the name given to the project (defaults to cwd)
+	Provider  string `json:"provider"`   // guest vm provider (virtual box, vmware, etc)
+	RAM       int    `json:"ram"`        // ammount of RAM to dedicate to the guest vm
+	HostDNS   string `json:"host_dns"`   // use the hosts dns resolver
+	SshPath   string `json:"ssh_path"`   // provide the path to the .ssh directory (if any)
 }
 
 // ParseNanofile
@@ -76,6 +77,11 @@ func ParseNanofile() NanofileConfig {
 	// if the OS is Windows folders CANNOT be mounted as NFS
 	if OS == "windows" {
 		nanofile.MountNFS = false
+	}
+
+	// if no dev config is provided, the default is "mount"
+	if nanofile.DevConfig == "" {
+		nanofile.DevConfig = "mount"
 	}
 
 	return nanofile


### PR DESCRIPTION
…itionl config option to the nanofile (devconfig) with a default of 'mount'. added a flag to the dev command that can set that value on the fly (overriding if necessary), and passing that in as a query param to the dev command