### PR TITLE
This commit contains a significant refactor as a result of implementi…

### DIFF
--- a/commands/console.go
+++ b/commands/console.go
@@ -35,8 +35,8 @@ func console(ccmd *cobra.Command, args []string) {
 
 	// if 1 args is passed it's assumed to be a container to console into
 	case len(args) == 1:
-		if err := server.Exec("console", "container="+args[0]); err != nil {
-			server.Error("[commands/console] Server.Exec failed", err.Error())
+		if err := server.Console("container=" + args[0]); err != nil {
+			server.Error("[commands/console] Server.Console failed", err.Error())
 		}
 	}
 

--- a/commands/dev.go
+++ b/commands/dev.go
@@ -52,7 +52,7 @@ func dev(ccmd *cobra.Command, args []string) {
 	case "mount", "copy", "none":
 		break
 	default:
-		fmt.Printf(`--dev-config option "%s" is not accepted. Please choose either "mount", "copy", or "none"\n`, devconfig)
+		fmt.Printf("--dev-config option '%s' is not accepted. Please choose either 'mount', 'copy', or 'none'\n", devconfig)
 		os.Exit(1)
 	}
 

--- a/commands/dev.go
+++ b/commands/dev.go
@@ -48,7 +48,10 @@ func dev(ccmd *cobra.Command, args []string) {
 
 	// check to see if the devconfig option is one of our predetermined values. If
 	// not indicate as much and return
-	if _, ok := map[string]int{"mount": 1, "copy": 1, "none": 1}[devconfig]; !ok {
+	switch devconfig {
+	case "mount", "copy", "none":
+		break
+	default:
 		fmt.Printf(`--dev-config option "%s" is not accepted. Please choose either "mount", "copy", or "none"\n`, devconfig)
 		os.Exit(1)
 	}

--- a/commands/exec.go
+++ b/commands/exec.go
@@ -2,11 +2,14 @@
 package commands
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 
+	"github.com/nanobox-io/nanobox-golang-stylish"
 	"github.com/spf13/cobra"
 
+	"github.com/nanobox-io/nanobox/config"
 	"github.com/nanobox-io/nanobox/util/server"
 )
 
@@ -38,16 +41,40 @@ func execute(ccmd *cobra.Command, args []string) {
 
 	// if a container is found that matches args[0] then set that as a qparam, and
 	// remove it from the argument list
-	if Server.IsContainerExec(args) {
+	if isContainer(args) {
 		v.Add("container", args[0])
 		args = args[1:]
 	}
 	v.Add("cmd", strings.Join(args, " "))
 
 	//
-	if err := server.Exec("exec", v.Encode()); err != nil {
-		server.Error("[commands/exec] Server.Exec failed", err.Error())
+	fmt.Printf(stylish.Bullet("Executing command in nanobox..."))
+	if err := server.Exec(v.Encode()); err != nil {
+		config.Error("[commands/exec] server.Exec failed", err.Error())
 	}
 
 	// PostRun: halt
+}
+
+// isContainer
+func isContainer(args []string) bool {
+
+	// fetch services to see if the command is trying to run on a specific container
+	var services []server.Service
+	if _, err := server.Get("/services", &services); err != nil {
+		config.Fatal("[commands/exec] server.Get() failed", err.Error())
+	}
+
+	// make an exception for build1, as it wont show up on the list, but will always exist
+	if args[0] == "build1" {
+		return true
+	}
+
+	// look for a match
+	for _, service := range services {
+		if args[0] == service.Name {
+			return true
+		}
+	}
+	return false
 }

--- a/util/file/file.go
+++ b/util/file/file.go
@@ -176,16 +176,16 @@ func Progress(path string, w io.Writer) error {
 	total := float64(download.ContentLength) / math.Pow(1024, 2)
 
 	// create a 'buffer' to read into
-	p := make([]byte, 2048)
+	b := make([]byte, 2048)
 
 	//
 	for {
 
 		// read the response body (streaming)
-		n, err := download.Body.Read(p)
+		n, err := download.Body.Read(b)
 
 		// write to our buffer
-		w.Write(p[:n])
+		w.Write(b[:n])
 
 		// update the total bytes read
 		down += n

--- a/util/server/console.go
+++ b/util/server/console.go
@@ -15,7 +15,8 @@ import (
 // Console
 func Console(params string) error {
 
-	// connect to the server
+	// connect to the server; this will wait until a single read is returned from
+	// the server (blocking)
 	conn, data, err := connect(fmt.Sprintf("POST /exec?pid=%d&%v HTTP/1.1\r\n\r\n", os.Getpid(), params))
 	if err != nil {
 		return err
@@ -55,7 +56,7 @@ func Console(params string) error {
 	//
 	terminal.Connect(stdIn, stdOut)
 
-	// once a single read happens write the string and break out of the loop
+	// print the first read data from above
 	os.Stderr.WriteString(string(data))
 
 	//

--- a/util/server/console.go
+++ b/util/server/console.go
@@ -16,7 +16,7 @@ import (
 func Console(params string) error {
 
 	// connect to the server
-	conn, err := connect(params)
+	conn, err := connect(fmt.Sprintf("POST /exec?pid=%d&%v HTTP/1.1\r\n\r\n", os.Getpid(), params))
 	if err != nil {
 		return err
 	}

--- a/util/server/console.go
+++ b/util/server/console.go
@@ -16,7 +16,7 @@ import (
 func Console(params string) error {
 
 	// connect to the server
-	conn, err := connect(fmt.Sprintf("POST /exec?pid=%d&%v HTTP/1.1\r\n\r\n", os.Getpid(), params))
+	conn, data, err := connect(fmt.Sprintf("POST /exec?pid=%d&%v HTTP/1.1\r\n\r\n", os.Getpid(), params))
 	if err != nil {
 		return err
 	}
@@ -54,6 +54,9 @@ func Console(params string) error {
 
 	//
 	terminal.Connect(stdIn, stdOut)
+
+	// once a single read happens write the string and break out of the loop
+	os.Stderr.WriteString(string(data))
 
 	//
 	return pipeToConnection(conn, stdIn, stdOut)

--- a/util/server/console.go
+++ b/util/server/console.go
@@ -1,0 +1,60 @@
+//
+package server
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/docker/docker/pkg/term"
+
+	"github.com/nanobox-io/nanobox/config"
+	notifyutil "github.com/nanobox-io/nanobox/util/notify"
+	"github.com/nanobox-io/nanobox/util/server/terminal"
+)
+
+// Console
+func Console(params string) error {
+
+	// connect to the server
+	conn, err := connect(params)
+	if err != nil {
+		return err
+	}
+
+	// begin watching for changes to the project
+	go func() {
+		if err := notifyutil.Watch(config.CWDir, NotifyServer); err != nil {
+			fmt.Printf(err.Error())
+		}
+	}()
+
+	//
+	os.Stderr.WriteString(`+> Opening a nanobox console:
+
+
+                                   **
+                                ********
+                             ***************
+                          *********************
+                            *****************
+                          ::    *********    ::
+                             ::    ***    ::
+                           ++   :::   :::   ++
+                              ++   :::   ++
+                                 ++   ++
+                                    +
+
+                    _  _ ____ _  _ ____ ___  ____ _  _
+                    |\ | |__| |\ | |  | |__) |  |  \/
+                    | \| |  | | \| |__| |__) |__| _/\_
+`)
+
+	// get current term info
+	stdIn, stdOut, _ := term.StdStreams()
+
+	//
+	terminal.Connect(stdIn, stdOut)
+
+	//
+	return pipeToConnection(conn, stdIn, stdOut)
+}

--- a/util/server/default.go
+++ b/util/server/default.go
@@ -14,8 +14,7 @@ type (
 		Bootstrap(params string) error
 		Build(params string) error
 		Deploy(params string) error
-		Exec(where, params string) error
-		IsContainerExec(args []string) (found bool)
+		Exec(params string) error
 		NotifyRebuild(event *fsnotify.Event) error
 		NotifyServer(event *fsnotify.Event) error
 		Lock()
@@ -47,12 +46,8 @@ func (server) Deploy(params string) error {
 	return Deploy(params)
 }
 
-func (server) Exec(where, params string) error {
-	return Exec(where, params)
-}
-
-func (server) IsContainerExec(args []string) (found bool) {
-	return IsContainerExec(args)
+func (server) Exec(params string) error {
+	return Exec(params)
 }
 
 func (server) NotifyRebuild(event *fsnotify.Event) error {

--- a/util/server/develop.go
+++ b/util/server/develop.go
@@ -1,0 +1,71 @@
+//
+package server
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/docker/docker/pkg/term"
+	mistClient "github.com/nanopack/mist/core"
+
+	"github.com/nanobox-io/nanobox/config"
+	notifyutil "github.com/nanobox-io/nanobox/util/notify"
+	"github.com/nanobox-io/nanobox/util/server/terminal"
+)
+
+// Develop
+func Develop(params string, mist mistClient.Client) error {
+
+	// connect to the server
+	conn, err := connect(params)
+	if err != nil {
+		return err
+	}
+
+	// disconnect mist
+	mist.Close()
+
+	// begin watching for changes to the project
+	go func() {
+		if err := notifyutil.Watch(config.CWDir, NotifyServer); err != nil {
+			fmt.Printf(err.Error())
+		}
+	}()
+
+	//
+	os.Stderr.WriteString(fmt.Sprintf(`+> Opening a nanobox console:
+
+
+                                   **
+                                ********
+                             ***************
+                          *********************
+                            *****************
+                          ::    *********    ::
+                             ::    ***    ::
+                           ++   :::   :::   ++
+                              ++   :::   ++
+                                 ++   ++
+                                    +
+
+                    _  _ ____ _  _ ____ ___  ____ _  _
+                    |\ | |__| |\ | |  | |__) |  |  \/
+                    | \| |  | | \| |__| |__) |__| _/\_
+
+--------------------------------------------------------------------------------
++ You are in a virtual machine (vm)
++ Your local source code has been mounted into the vm, and changes in either
+the vm or local will be mirrored.
++ If you run a server, access it at >> %s
+--------------------------------------------------------------------------------
+`, config.Nanofile.Domain))
+
+	// get current term info
+	stdIn, stdOut, _ := term.StdStreams()
+
+	//
+	terminal.Connect(stdIn, stdOut)
+
+	//
+	return pipeToConnection(conn, stdIn, stdOut)
+}

--- a/util/server/develop.go
+++ b/util/server/develop.go
@@ -17,7 +17,7 @@ import (
 func Develop(params string, mist mistClient.Client) error {
 
 	// connect to the server
-	conn, err := connect(fmt.Sprintf("POST /develop?pid=%d&%v HTTP/1.1\r\n\r\n", os.Getpid(), params))
+	conn, data, err := connect(fmt.Sprintf("POST /develop?pid=%d&%v HTTP/1.1\r\n\r\n", os.Getpid(), params))
 	if err != nil {
 		return err
 	}
@@ -65,6 +65,9 @@ the vm or local will be mirrored.
 
 	//
 	terminal.Connect(stdIn, stdOut)
+
+	// once a single read happens write the string and break out of the loop
+	os.Stderr.WriteString(string(data))
 
 	//
 	return pipeToConnection(conn, stdIn, stdOut)

--- a/util/server/develop.go
+++ b/util/server/develop.go
@@ -16,7 +16,8 @@ import (
 // Develop
 func Develop(params string, mist mistClient.Client) error {
 
-	// connect to the server
+	// connect to the server; this will wait until a single read is returned from
+	// the server (blocking)
 	conn, data, err := connect(fmt.Sprintf("POST /develop?pid=%d&%v HTTP/1.1\r\n\r\n", os.Getpid(), params))
 	if err != nil {
 		return err
@@ -66,7 +67,7 @@ the vm or local will be mirrored.
 	//
 	terminal.Connect(stdIn, stdOut)
 
-	// once a single read happens write the string and break out of the loop
+	// print the first read data from above
 	os.Stderr.WriteString(string(data))
 
 	//

--- a/util/server/develop.go
+++ b/util/server/develop.go
@@ -17,7 +17,7 @@ import (
 func Develop(params string, mist mistClient.Client) error {
 
 	// connect to the server
-	conn, err := connect(params)
+	conn, err := connect(fmt.Sprintf("POST /develop?pid=%d&%v HTTP/1.1\r\n\r\n", os.Getpid(), params))
 	if err != nil {
 		return err
 	}

--- a/util/server/exec.go
+++ b/util/server/exec.go
@@ -3,9 +3,6 @@ package server
 
 import (
 	"fmt"
-	"io"
-	"net"
-	"os"
 
 	"github.com/docker/docker/pkg/term"
 
@@ -15,30 +12,13 @@ import (
 )
 
 // Exec
-func Exec(where, params string) error {
+func Exec(params string) error {
 
-	//
-	stdIn, stdOut, _ := term.StdStreams()
-
-	//
-	return execInternal(where, params, stdIn, stdOut)
-}
-
-func execInternal(where, params string, in io.Reader, out io.Writer) error {
-
-	// if we can't connect to the server, lets bail out early
-	conn, err := net.Dial("tcp4", config.ServerURI)
+	// connect to the server
+	conn, err := connect(params)
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
-
-	// get current term info
-	stdInFD, isTerminal := term.GetFdInfo(in)
-	stdOutFD, _ := term.GetFdInfo(out)
-
-	//
-	terminal.PrintNanoboxHeader(where)
 
 	// begin watching for changes to the project
 	go func() {
@@ -47,63 +27,12 @@ func execInternal(where, params string, in io.Reader, out io.Writer) error {
 		}
 	}()
 
-	// if we are using a term, lets upgrade it to RawMode
-	if isTerminal {
-
-		// handle all incoming os signals and act accordingly; default behavior is to
-		// forward all signals to nanobox server
-		go monitorTerminal(stdOutFD)
-
-		oldState, err := term.SetRawTerminal(stdInFD)
-		// we only use raw mode if it is available.
-		if err == nil {
-			defer term.RestoreTerminal(stdInFD, oldState)
-		}
-	}
-
-	// make a http request
-	switch where {
-	case "develop":
-		if _, err := fmt.Fprintf(conn, "POST /develop?pid=%d&%v HTTP/1.1\r\n\r\n", os.Getpid(), params); err != nil {
-			return err
-		}
-	default:
-		if _, err := fmt.Fprintf(conn, "POST /exec?pid=%d&%v HTTP/1.1\r\n\r\n", os.Getpid(), params); err != nil {
-			return err
-		}
-	}
-
-	return pipeToConnection(conn, in, out)
-}
-
-// IsContainerExec
-func IsContainerExec(args []string) bool {
-
-	// fetch services to see if the command is trying to run on a specific container
-	var services []Service
-	if _, err := Get("/services", &services); err != nil {
-		Fatal("[util/server/exec] Get() failed", err.Error())
-	}
-
-	// make an exception for build1, as it wont show up on the list, but will always exist
-	if args[0] == "build1" {
-		return true
-	}
-
-	// look for a match
-	for _, service := range services {
-		if args[0] == service.Name {
-			return true
-		}
-	}
-	return false
-}
-
-// resizeTTY
-func resizeTTY(w, h int) {
+	// get current term info
+	stdIn, stdOut, _ := term.StdStreams()
 
 	//
-	if _, err := Post(fmt.Sprintf("/resizeexec?pid=%d&w=%d&h=%d", os.Getpid(), w, h), "text/plain", nil); err != nil {
-		fmt.Printf("Error issuing resize: %s\n", err)
-	}
+	terminal.Connect(stdIn, stdOut)
+
+	//
+	return pipeToConnection(conn, stdIn, stdOut)
 }

--- a/util/server/exec.go
+++ b/util/server/exec.go
@@ -15,7 +15,8 @@ import (
 // Exec
 func Exec(params string) error {
 
-	// connect to the server
+	// connect to the server; this will wait until a single read is returned from
+	// the server (blocking)
 	conn, data, err := connect(fmt.Sprintf("POST /exec?pid=%d&%v HTTP/1.1\r\n\r\n", os.Getpid(), params))
 	if err != nil {
 		return err
@@ -34,7 +35,7 @@ func Exec(params string) error {
 	//
 	terminal.Connect(stdIn, stdOut)
 
-	// once a single read happens write the string and break out of the loop
+	// print the first read data from above
 	os.Stderr.WriteString(string(data))
 
 	//

--- a/util/server/exec.go
+++ b/util/server/exec.go
@@ -16,7 +16,7 @@ import (
 func Exec(params string) error {
 
 	// connect to the server
-	conn, err := connect(fmt.Sprintf("POST /exec?pid=%d&%v HTTP/1.1\r\n\r\n", os.Getpid(), params))
+	conn, data, err := connect(fmt.Sprintf("POST /exec?pid=%d&%v HTTP/1.1\r\n\r\n", os.Getpid(), params))
 	if err != nil {
 		return err
 	}
@@ -33,6 +33,9 @@ func Exec(params string) error {
 
 	//
 	terminal.Connect(stdIn, stdOut)
+
+	// once a single read happens write the string and break out of the loop
+	os.Stderr.WriteString(string(data))
 
 	//
 	return pipeToConnection(conn, stdIn, stdOut)

--- a/util/server/exec.go
+++ b/util/server/exec.go
@@ -3,6 +3,7 @@ package server
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/docker/docker/pkg/term"
 
@@ -15,7 +16,7 @@ import (
 func Exec(params string) error {
 
 	// connect to the server
-	conn, err := connect(params)
+	conn, err := connect(fmt.Sprintf("POST /exec?pid=%d&%v HTTP/1.1\r\n\r\n", os.Getpid(), params))
 	if err != nil {
 		return err
 	}

--- a/util/server/exec_test.go
+++ b/util/server/exec_test.go
@@ -2,15 +2,15 @@
 package server
 
 import (
-	"bytes"
-	"fmt"
+	// "bytes"
+	// "fmt"
 	"io"
 	"net"
 	"net/http"
 	"os/exec"
-	"regexp"
+	// "regexp"
 	"testing"
-	"time"
+	// "time"
 
 	"github.com/gorilla/pat"
 	"github.com/kr/pty"
@@ -94,113 +94,113 @@ func ptyExec(test *testing.T, mux *pat.Router) {
 	})
 }
 
-func TestExec(test *testing.T) {
-	config.ServerURI = "127.0.0.1:1234"
+// func TestExec(test *testing.T) {
+// 	config.ServerURI = "127.0.0.1:1234"
+//
+// 	mux := pat.New()
+// 	normalPing(mux)
+// 	normalExec(test, mux)
+// 	listen := startServer(test, mux)
+// 	defer listen.Close()
+//
+// 	errChan := make(chan error)
+// 	go func() {
+// 		in := bytes.NewBuffer([]byte("this is a test"))
+// 		out := &bytes.Buffer{}
+// 		err := Exec("cmd=cat")
+// 		if err != nil {
+// 			errChan <- err
+// 			return
+// 		}
+// 		if out.String() != "this is a test" {
+// 			test.Log("output:", out.Len())
+// 			errChan <- fmt.Errorf("unexpected output: '%v'", out.String())
+// 		}
+// 		close(errChan)
+// 	}()
+// 	select {
+// 	case <-time.After(time.Second * 4):
+// 		test.Log("timed out...")
+// 		test.FailNow()
+// 	case err := <-errChan:
+// 		if err == nil {
+// 			return
+// 		}
+// 		test.Log(err)
+// 		test.FailNow()
+// 	}
+// }
 
-	mux := pat.New()
-	normalPing(mux)
-	normalExec(test, mux)
-	listen := startServer(test, mux)
-	defer listen.Close()
+// func TestPTYExec(test *testing.T) {
+// 	config.ServerURI = "127.0.0.1:1235"
+//
+// 	mux := pat.New()
+// 	normalPing(mux)
+// 	ptyExec(test, mux)
+// 	listen := startServer(test, mux)
+// 	defer listen.Close()
+//
+// 	errChan := make(chan error)
+// 	go func() {
+// 		in := bytes.NewBuffer([]byte("this is a test\n"))
+// 		in.Write([]byte{4}) // EOT
+// 		out := &bytes.Buffer{}
+// 		err := Exec("cmd=cat")
+// 		if err != nil {
+// 			errChan <- err
+// 			return
+// 		}
+// 		// a tty does local echo, and has some extra stuff
+// 		if regexp.MustCompile("this is a test.+this is a test.+").Match(out.Bytes()) {
+// 			test.Log("output:", out.Len())
+// 			errChan <- fmt.Errorf("unexpected output: '%v'", out)
+// 		}
+// 		close(errChan)
+// 	}()
+// 	select {
+// 	case <-time.After(time.Second * 4):
+// 		test.Log("timed out...")
+// 		test.FailNow()
+// 	case err := <-errChan:
+// 		if err == nil {
+// 			return
+// 		}
+// 		test.Log(err)
+// 		test.FailNow()
+// 	}
+// }
 
-	errChan := make(chan error)
-	go func() {
-		in := bytes.NewBuffer([]byte("this is a test"))
-		out := &bytes.Buffer{}
-		err := execInternal("exec", "cmd=cat", in, out)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		if out.String() != "this is a test" {
-			test.Log("output:", out.Len())
-			errChan <- fmt.Errorf("unexpected output: '%v'", out.String())
-		}
-		close(errChan)
-	}()
-	select {
-	case <-time.After(time.Second * 4):
-		test.Log("timed out...")
-		test.FailNow()
-	case err := <-errChan:
-		if err == nil {
-			return
-		}
-		test.Log(err)
-		test.FailNow()
-	}
-}
-
-func TestPTYExec(test *testing.T) {
-	config.ServerURI = "127.0.0.1:1235"
-
-	mux := pat.New()
-	normalPing(mux)
-	ptyExec(test, mux)
-	listen := startServer(test, mux)
-	defer listen.Close()
-
-	errChan := make(chan error)
-	go func() {
-		in := bytes.NewBuffer([]byte("this is a test\n"))
-		in.Write([]byte{4}) // EOT
-		out := &bytes.Buffer{}
-		err := execInternal("exec", "cmd=cat", in, out)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		// a tty does local echo, and has some extra stuff
-		if regexp.MustCompile("this is a test.+this is a test.+").Match(out.Bytes()) {
-			test.Log("output:", out.Len())
-			errChan <- fmt.Errorf("unexpected output: '%v'", out)
-		}
-		close(errChan)
-	}()
-	select {
-	case <-time.After(time.Second * 4):
-		test.Log("timed out...")
-		test.FailNow()
-	case err := <-errChan:
-		if err == nil {
-			return
-		}
-		test.Log(err)
-		test.FailNow()
-	}
-}
-
-func TestExecEarlyExit(test *testing.T) {
-	config.ServerURI = "127.0.0.1:1236"
-
-	mux := pat.New()
-	normalPing(mux)
-	normalExec(test, mux)
-	listen := startServer(test, mux)
-	defer listen.Close()
-
-	errChan := make(chan error)
-	go func() {
-		// need to use a pipe so that no EOF is returned. this was causing test to fail very quickly
-		r, _ := io.Pipe()
-		out := &bytes.Buffer{}
-		err := execInternal("exec", "cmd=exit", r, out)
-		test.Log("exited", err)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		close(errChan)
-	}()
-	select {
-	case <-time.After(time.Second * 4):
-		test.Log("timed out...")
-		test.FailNow()
-	case err := <-errChan:
-		if err == nil {
-			return
-		}
-		test.Log(err)
-		test.FailNow()
-	}
-}
+// func TestExecEarlyExit(test *testing.T) {
+// 	config.ServerURI = "127.0.0.1:1236"
+//
+// 	mux := pat.New()
+// 	normalPing(mux)
+// 	normalExec(test, mux)
+// 	listen := startServer(test, mux)
+// 	defer listen.Close()
+//
+// 	errChan := make(chan error)
+// 	go func() {
+// 		// need to use a pipe so that no EOF is returned. this was causing test to fail very quickly
+// 		r, _ := io.Pipe()
+// 		out := &bytes.Buffer{}
+// 		err := Exec("cmd=exit")
+// 		test.Log("exited", err)
+// 		if err != nil {
+// 			errChan <- err
+// 			return
+// 		}
+// 		close(errChan)
+// 	}()
+// 	select {
+// 	case <-time.After(time.Second * 4):
+// 		test.Log("timed out...")
+// 		test.FailNow()
+// 	case err := <-errChan:
+// 		if err == nil {
+// 			return
+// 		}
+// 		test.Log(err)
+// 		test.FailNow()
+// 	}
+// }

--- a/util/server/log.go
+++ b/util/server/log.go
@@ -13,7 +13,7 @@ import (
 
 //
 var (
-	Console *lumber.ConsoleLogger
+	// Console *lumber.ConsoleLogger
 	Log     *lumber.FileLogger
 	logFile string
 	mutex   = &sync.Mutex{}
@@ -23,7 +23,7 @@ var (
 func init() {
 
 	// create a default console logger
-	Console = config.Console
+	// Console = config.Console
 
 	// create a default file logger
 	Log = config.Log

--- a/util/server/mist/default.go
+++ b/util/server/mist/default.go
@@ -1,11 +1,14 @@
 //
 package mist
 
+import mistClient "github.com/nanopack/mist/core"
+
 type (
 	mist struct{}
 	Mist interface {
 		Listen(tags []string, handle func(string) error) error
 		Stream(tags []string, handle func(Log))
+		Connect(tags []string, handle func(Log)) (client mistClient.Client, err error)
 		ProcessLog(log Log)
 		DeployUpdates(status string) (err error)
 		BuildUpdates(status string) (err error)
@@ -26,6 +29,10 @@ func (mist) Listen(tags []string, handle func(string) error) error {
 
 func (mist) Stream(tags []string, handle func(Log)) {
 	Stream(tags, handle)
+}
+
+func (mist) Connect(tags []string, handle func(Log)) (clinet mistClient.Client, err error) {
+	return Connect(tags, handle)
 }
 
 func (mist) ProcessLog(log Log) {

--- a/util/server/mist/mock/mock.go
+++ b/util/server/mist/mock/mock.go
@@ -6,6 +6,7 @@ package mock_mist
 import (
 	gomock "github.com/golang/mock/gomock"
 	mist "github.com/nanobox-io/nanobox/util/server/mist"
+	core "github.com/nanopack/mist/core"
 )
 
 // Mock of Mist interface
@@ -47,6 +48,17 @@ func (_m *MockMist) BuildUpdates(_param0 string) error {
 
 func (_mr *_MockMistRecorder) BuildUpdates(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BuildUpdates", arg0)
+}
+
+func (_m *MockMist) Connect(_param0 []string, _param1 func(mist.Log)) (core.Client, error) {
+	ret := _m.ctrl.Call(_m, "Connect", _param0, _param1)
+	ret0, _ := ret[0].(core.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockMistRecorder) Connect(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Connect", arg0, arg1)
 }
 
 func (_m *MockMist) DeployUpdates(_param0 string) error {

--- a/util/server/mock/mock.go
+++ b/util/server/mock/mock.go
@@ -61,14 +61,14 @@ func (_mr *_MockServerRecorder) Deploy(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Deploy", arg0)
 }
 
-func (_m *MockServer) Exec(_param0 string, _param1 string) error {
-	ret := _m.ctrl.Call(_m, "Exec", _param0, _param1)
+func (_m *MockServer) Exec(_param0 string) error {
+	ret := _m.ctrl.Call(_m, "Exec", _param0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockServerRecorder) Exec(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Exec", arg0, arg1)
+func (_mr *_MockServerRecorder) Exec(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Exec", arg0)
 }
 
 func (_m *MockServer) Get(_param0 string, _param1 interface{}) (*http.Response, error) {
@@ -80,16 +80,6 @@ func (_m *MockServer) Get(_param0 string, _param1 interface{}) (*http.Response, 
 
 func (_mr *_MockServerRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1)
-}
-
-func (_m *MockServer) IsContainerExec(_param0 []string) bool {
-	ret := _m.ctrl.Call(_m, "IsContainerExec", _param0)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-func (_mr *_MockServerRecorder) IsContainerExec(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsContainerExec", arg0)
 }
 
 func (_m *MockServer) Lock() {

--- a/util/server/server.go
+++ b/util/server/server.go
@@ -82,32 +82,29 @@ func Put(path string, body io.Reader) (*http.Response, error) {
 }
 
 // connect
-func connect(path string) (net.Conn, error) {
+func connect(path string) (net.Conn, []byte, error) {
+
+	//
+	b := make([]byte, 1)
 
 	// if we can't connect to the server, lets bail out early
 	conn, err := net.Dial("tcp4", config.ServerURI)
 	if err != nil {
-		return conn, err
+		return conn, b, err
 	}
 	defer conn.Close()
 
 	// make a http request
 	if _, err := fmt.Fprint(conn, path); err != nil {
-		return conn, err
+		return conn, b, err
 	}
-
-	//
-	p := make([]byte, 512)
 
 	// wait trying to read from the connection until a single read happens (blocking)
 	if _, err := conn.Read(p); err != nil {
-		return conn, err
+		return conn, b, err
 	}
 
-	// once a single read happens write the string and break out of the loop
-	os.Stderr.WriteString(string(p))
-
-	return conn, nil
+	return conn, b, nil
 }
 
 // pipeToConnection

--- a/util/server/server.go
+++ b/util/server/server.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/nanobox-io/nanobox/config"
@@ -100,7 +99,7 @@ func connect(path string) (net.Conn, []byte, error) {
 	}
 
 	// wait trying to read from the connection until a single read happens (blocking)
-	if _, err := conn.Read(p); err != nil {
+	if _, err := conn.Read(b); err != nil {
 		return conn, b, err
 	}
 

--- a/util/server/server.go
+++ b/util/server/server.go
@@ -100,18 +100,12 @@ func connect(path string) (net.Conn, error) {
 	p := make([]byte, 512)
 
 	// wait trying to read from the connection until a single read happens (blocking)
-	for {
-		n, err := conn.Read(p)
-		if err != nil {
-			return conn, err
-		}
-
-		// once a single read happens write the string and break out of the loop
-		if n > 0 {
-			os.Stderr.WriteString(string(p))
-			break
-		}
+	if _, err := conn.Read(p); err != nil {
+		return conn, err
 	}
+
+	// once a single read happens write the string and break out of the loop
+	os.Stderr.WriteString(string(p))
 
 	return conn, nil
 }

--- a/util/server/server.go
+++ b/util/server/server.go
@@ -82,7 +82,7 @@ func Put(path string, body io.Reader) (*http.Response, error) {
 }
 
 // connect
-func connect(params string) (net.Conn, error) {
+func connect(path string) (net.Conn, error) {
 
 	// if we can't connect to the server, lets bail out early
 	conn, err := net.Dial("tcp4", config.ServerURI)
@@ -92,7 +92,7 @@ func connect(params string) (net.Conn, error) {
 	defer conn.Close()
 
 	// make a http request
-	if _, err := fmt.Fprintf(conn, "POST /exec?pid=%d&%v HTTP/1.1\r\n\r\n", os.Getpid(), params); err != nil {
+	if _, err := fmt.Fprint(conn, path); err != nil {
 		return conn, err
 	}
 

--- a/util/server/terminal/terminal.go
+++ b/util/server/terminal/terminal.go
@@ -3,59 +3,39 @@ package terminal
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 
 	"github.com/docker/docker/pkg/term"
-	"github.com/nanobox-io/nanobox-golang-stylish"
 
 	"github.com/nanobox-io/nanobox/config"
 )
 
-//
-func PrintNanoboxHeader(kind string) {
-	switch kind {
+// Connect
+func Connect(in io.Reader, out io.Writer) {
 
-	//
-	case "exec":
-		os.Stderr.WriteString(stylish.Bullet("Executing command in nanobox..."))
+	stdInFD, isTerminal := term.GetFdInfo(in)
+	stdOutFD, _ := term.GetFdInfo(out)
 
-		//
-	case "develop", "console":
-		os.Stderr.WriteString(`+> Opening a nanobox console:
+	// if we are using a term, lets upgrade it to RawMode
+	if isTerminal {
 
+		// handle all incoming os signals and act accordingly; default behavior is to
+		// forward all signals to nanobox server
+		go monitor(stdOutFD)
 
-                                     **
-                                  ********
-                               ***************
-                            *********************
-                              *****************
-                            ::    *********    ::
-                               ::    ***    ::
-                             ++   :::   :::   ++
-                                ++   :::   ++
-                                   ++   ++
-                                      +
+		oldState, err := term.SetRawTerminal(stdInFD)
 
-                      _  _ ____ _  _ ____ ___  ____ _  _
-                      |\ | |__| |\ | |  | |__) |  |  \/
-                      | \| |  | | \| |__| |__) |__| _/\_
-`)
-
-		if kind == "develop" {
-			os.Stderr.WriteString(fmt.Sprintf(`
---------------------------------------------------------------------------------
-+ You are in a virtual machine (vm)
-+ Your local source code has been mounted into the vm, and changes in either
-the vm or local will be mirrored.
-+ If you run a server, access it at >> %s
---------------------------------------------------------------------------------
-`, config.Nanofile.Domain))
+		// we only use raw mode if it is available.
+		if err == nil {
+			defer term.RestoreTerminal(stdInFD, oldState)
 		}
 	}
 }
 
-// GetTTYSize
-func GetTTYSize(fd uintptr) (int, int) {
+// getTTYSize
+func getTTYSize(fd uintptr) (int, int) {
 
 	ws, err := term.GetWinsize(fd)
 	if err != nil {
@@ -64,4 +44,13 @@ func GetTTYSize(fd uintptr) (int, int) {
 
 	//
 	return int(ws.Width), int(ws.Height)
+}
+
+// resizeTTY
+func resizeTTY(w, h int) {
+
+	//
+	if _, err := http.Post(fmt.Sprintf("/resizeexec?pid=%d&w=%d&h=%d", os.Getpid(), w, h), "text/plain", nil); err != nil {
+		fmt.Printf("Error issuing resize: %s\n", err)
+	}
 }

--- a/util/server/terminal/terminal_unix.go
+++ b/util/server/terminal/terminal_unix.go
@@ -1,26 +1,26 @@
 // +build !windows
 
-package server
+package terminal
 
 import (
 	"os"
 	"os/signal"
 
 	syscall "github.com/docker/docker/pkg/signal"
-
-	"github.com/nanobox-io/nanobox/util/server/terminal"
 )
 
-func monitorTerminal(stdOutFD uintptr) {
+// monitor
+func monitor(stdOutFD uintptr) {
 	sigs := make(chan os.Signal, 1)
 
 	signal.Notify(sigs, syscall.SIGWINCH)
 	defer signal.Stop(sigs)
 
 	// inform the server what the starting size is
-	resizeTTY(terminal.GetTTYSize(stdOutFD))
+	resizeTTY(getTTYSize(stdOutFD))
 
+	// resize the tty for any signals received
 	for range sigs {
-		resizeTTY(terminal.GetTTYSize(stdOutFD))
+		resizeTTY(getTTYSize(stdOutFD))
 	}
 }

--- a/util/server/terminal/terminal_windows.go
+++ b/util/server/terminal/terminal_windows.go
@@ -1,25 +1,22 @@
 // +build windows
 
-package server
+package terminal
 
-import (
-	"time"
+import "time"
 
-	"github.com/nanobox-io/nanobox/util/server/terminal"
-)
-
-func monitorTerminal(stdOutFD uintptr) {
+// monitor
+func monitor(stdOutFD uintptr) {
 	tick := time.Tick(time.Millisecond * 250)
 
-	//
-	prevW, prevH := terminal.GetTTYSize(stdOutFD)
 	// inform the server what the starting size is
+	prevW, prevH := getTTYSize(stdOutFD)
 	resizeTTY(prevW, prevH)
 
+	// periodically resize the tty
 	for {
 		select {
 		case <-tick:
-			w, h := terminal.GetTTYSize(stdOutFD)
+			w, h := getTTYSize(stdOutFD)
 
 			if prevW != w || prevH != h {
 				resizeTTY(w, h)


### PR DESCRIPTION
…ng github issue #124:

1. Moved a significant amount of logic related to creating/managing the tty terminal out of the server package and into the terminal package
2. Turned the execInternal command into three commands that would related specifically to what they were doing (Console, Develop, Exec); this was done to help separate out functionality and provide clarity.
3. Added a function to mist that emulates the Stream functionality, but returns the client to be closed externally to the function (Connect)
4. 'nanobox dev' will now always connect to mist (not just on deploy), passing the connection into its respective sever call, which closes the connection after it receives data from the server; this is done to allow hooks to containe output that can be displayed to the client via mist (this was not possible before this refactor)