### PR TITLE
Privililage escalation on updater 

### DIFF
--- a/updater/main.go
+++ b/updater/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"runtime"
 
 	"github.com/nanobox-io/nanobox/util"
@@ -12,6 +13,18 @@ import (
 
 // main ...
 func main() {
+
+	path := ""
+	var err error
+	if len(os.Args) > 1 {
+		path = os.Args[1]
+	} else {
+		// get the location of the current nanobox
+		path, err = exec.LookPath(update.Name)
+		if err != nil {
+			fmt.Printf("Cannot find %s: %s\n", update.Name, err)
+		}
+	}
 
 	if !util.IsPrivileged() {
 
@@ -29,7 +42,7 @@ func main() {
 
 		}
 
-		cmd := fmt.Sprintf("%s", os.Args[0])
+		cmd := fmt.Sprintf("%s %s", os.Args[0], path)
 		if err := util.PrivilegeExec(cmd); err != nil {
 			os.Exit(1)
 		}
@@ -39,7 +52,7 @@ func main() {
 	}
 
 	// run the update
-	err := update.Run()
+	err = update.Run(path)
 	if err != nil {
 		fmt.Println("error: %s", err)
 	}

--- a/util/display/download_percent.go
+++ b/util/display/download_percent.go
@@ -16,6 +16,7 @@ type DownloadPercent struct {
 }
 
 func (dp *DownloadPercent) Copy(writer io.Writer, reader io.Reader) (err error) {
+	fmt.Println()
 	// initialize variables
 	buf := make([]byte, 32*1024)
 	dp.current = 0
@@ -59,6 +60,7 @@ func (dp *DownloadPercent) Copy(writer io.Writer, reader io.Reader) (err error) 
 		dp.current = dp.Total
 		dp.UpdateDisplay()
 	}
+	fmt.Println()
 	return err
 }
 

--- a/util/update/name.go
+++ b/util/update/name.go
@@ -2,5 +2,5 @@
 
 package update
 
-const name = "nanobox"
+const Name = "nanobox"
 const tmpName = "nanobox.tmp"

--- a/util/update/name_windows.go
+++ b/util/update/name_windows.go
@@ -1,4 +1,4 @@
 package update
 
-const name = "nanobox.exe"
+const Name = "nanobox.exe"
 const tmpName = "nanobox-tmp.exe"

--- a/util/update/run.go
+++ b/util/update/run.go
@@ -1,9 +1,9 @@
 package update
 
 import (
+	"fmt"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/nanobox-io/nanobox/models"
@@ -11,16 +11,12 @@ import (
 	"github.com/nanobox-io/nanobox/util/display"
 )
 
-func Run() error {
-
-	// get the location of the current nanobox
-	path, err := exec.LookPath(name)
-	if err != nil {
-		return err
+func Run(path string) error {
+	if path == "" {
+		fmt.Errorf("invalid path")
 	}
 
 	// create a temporary file
-
 	tmpFileName := filepath.Join(filepath.Dir(path), tmpName)
 	tmpFile, err := os.OpenFile(tmpFileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
 	if err != nil {

--- a/util/update/update.go
+++ b/util/update/update.go
@@ -14,7 +14,7 @@ import (
 )
 
 func RemotePath() string {
-	return fmt.Sprintf("https://s3.amazonaws.com/tools.nanobox.io/nanobox/v1/%s/%s/%s", runtime.GOOS, runtime.GOARCH, name)
+	return fmt.Sprintf("https://s3.amazonaws.com/tools.nanobox.io/nanobox/v1/%s/%s/%s", runtime.GOOS, runtime.GOARCH, Name)
 }
 
 func RemoveMd5() string {


### PR DESCRIPTION
Fix a problem where nanobox wasn't in a global path but was  in a local. When we privilege escalated it the admin user wouldn't know where to find the nanobox binary.