### PR TITLE
mounts dont need to check for a stale mount

### DIFF
--- a/util/provider/dockermachine_mount.go
+++ b/util/provider/dockermachine_mount.go
@@ -32,7 +32,7 @@ func (machine DockerMachine) HasMount(mount string) bool {
 		return false
 
 	}
-	return strings.Contains(string(output), mount) && !machine.staleMount(mount)
+	return strings.Contains(string(output), mount) // && !machine.staleMount(mount)
 }
 
 func (machine DockerMachine) staleMount(mount string) bool {


### PR DESCRIPTION
this should speed up the process a great deal