### PR TITLE
fix windows cursor for cmd

### DIFF
--- a/util/console/console.go
+++ b/util/console/console.go
@@ -43,8 +43,9 @@ func Run(id string, consoleConfig ConsoleConfig) error {
 	cmd = append(cmd, cmdPart)
 
 	// establish file descriptors for std streams
-	stdInFD, isTerminal := term.GetFdInfo(os.Stdin)
-	stdOutFD, _ := term.GetFdInfo(os.Stdout)
+	stdin, stdout, _ := term.StdStreams()
+	stdInFD, isTerminal := term.GetFdInfo(stdin)
+	stdOutFD, _ := term.GetFdInfo(stdout)
 
 	// initiate a docker exec
 	execConfig := docker.ExecConfig{


### PR DESCRIPTION
fixes #265
this doesnt work in cmder and im still not sure it works in other os's