### PR TITLE
allow shares to be removed when the mount isnt present

### DIFF
--- a/processors/env/unmount.go
+++ b/processors/env/unmount.go
@@ -12,10 +12,6 @@ import (
 
 // Unmount unmounts the env shares
 func Unmount(env *models.Env) error {
-	// break early if we're not mounted
-	if !mounted(env) {
-		return nil
-	}
 
 	// break early if there is still an environemnt using the mounts
 	if mountsInUse(env) {

--- a/util/provider/dockermachine_mount.go
+++ b/util/provider/dockermachine_mount.go
@@ -110,13 +110,11 @@ func (machine DockerMachine) AddMount(local, host string) error {
 
 // RemoveMount removes a mount from the docker-machine vm
 func (machine DockerMachine) RemoveMount(local, host string) error {
-	if !machine.HasMount(host) {
-		return nil
-	}
-
-	// all mounts are removed as if they are native
-	if err := machine.removeNativeMount(local, host); err != nil {
-		return err
+	if machine.HasMount(host) {
+		// all mounts are removed as if they are native
+		if err := machine.removeNativeMount(local, host); err != nil {
+			return err
+		}
 	}
 
 	// if we are supposed to keep the shares return here

--- a/util/provider/native.go
+++ b/util/provider/native.go
@@ -30,8 +30,7 @@ func (native Native) Valid() (bool, []string) {
 	cmd := exec.Command("docker", "ps")
 
 	//
-	if out, err := cmd.CombinedOutput(); err != nil {
-		fmt.Println(string(out))
+	if _, err := cmd.CombinedOutput(); err != nil {
 		return false, []string{"docker"}
 	}
 


### PR DESCRIPTION
The guard statment was stopping us from removing the share
in the case where the network share was not currently mounted
during the unmount process