### PR TITLE
Pre-validate console node. Print helpful output

### DIFF
--- a/commands/console.go
+++ b/commands/console.go
@@ -61,6 +61,12 @@ ex: nanobox console local web.site
 		}
 
 		componentModel, _ := models.FindComponentBySlug(config.EnvID()+"_"+name, args[0])
+		// todo: determine ways this errors and handle it, use util.Err for suggestions
+		// componentModel, err := models.FindComponentBySlug(config.EnvID()+"_"+name, args[0])
+		// if err != nil {
+		// 	display.CommandErr(err)
+		// 	return
+		// }
 
 		display.CommandErr(env.Console(componentModel, console.ConsoleConfig{}))
 

--- a/processors/env/console.go
+++ b/processors/env/console.go
@@ -5,12 +5,22 @@ import (
 
 	"github.com/nanobox-io/nanobox/models"
 	"github.com/nanobox-io/nanobox/processors/provider"
+	"github.com/nanobox-io/nanobox/util"
 	"github.com/nanobox-io/nanobox/util/console"
 	"github.com/nanobox-io/nanobox/util/display"
 )
 
 // Console ...
 func Console(componentModel *models.Component, consoleConfig console.ConsoleConfig) error {
+	if componentModel.ID == "" {
+		display.ConsoleNodeNotFound()
+		return util.Err{
+			Message: "Node not found",
+			Code:    "USER",
+			Stack:   []string{"failed to console"},
+			Suggest: "It appears the node specified does not exist. Please double check the node name in your boxfile.yml.",
+		}
+	}
 	// setup docker client
 	if err := provider.Init(); err != nil {
 		return err

--- a/util/display/messages.go
+++ b/util/display/messages.go
@@ -332,8 +332,8 @@ func ConsoleNodeNotFound() {
 --------------------------------------------------------------------------------
 NODE NOT FOUND
 It appears the node you are trying to console to does not exist. Please double
-check your boxfile. If your boxfile does contain a node by the name you
-specified, please let support know.
+check your boxfile.yml. If your boxfile.yml does contain a node by the name you
+specified, please contact support.
 --------------------------------------------------------------------------------
 `))
 }

--- a/util/display/messages.go
+++ b/util/display/messages.go
@@ -326,3 +326,14 @@ the '-p' flag. (eg. 'nanobox tunnel data.db -p 5444')
 --------------------------------------------------------------------------------
 `, port))
 }
+
+func ConsoleNodeNotFound() {
+	os.Stderr.WriteString(fmt.Sprintf(`
+--------------------------------------------------------------------------------
+NODE NOT FOUND
+It appears the node you are trying to console to does not exist. Please double
+check your boxfile. If your boxfile does contain a node by the name you
+specified, please let support know.
+--------------------------------------------------------------------------------
+`))
+}


### PR DESCRIPTION
If a user tries consoling to a node they don't have specified in their boxfile, they will now be alerted to verify the node name.

Resolves #516 
