### PR TITLE
Support https when deployed locally (dry-run)

### DIFF
--- a/generators/router/certs.go
+++ b/generators/router/certs.go
@@ -1,0 +1,92 @@
+package router
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/nanobox-io/golang-portal-client"
+
+	"github.com/nanobox-io/nanobox/models"
+)
+
+func BuildCert(appModel *models.App) ([]portal.CertBundle, error) {
+	certs := []portal.CertBundle{}
+
+	var err error
+	var key, cert string
+
+	if appModel.Key == "" {
+		key, cert, err = generate()
+		if err != nil {
+			return nil, fmt.Errorf("Failed to generate cert %s", err.Error())
+		}
+
+		appModel.Key = key
+		appModel.Cert = cert
+		err = appModel.Save()
+		if err != nil {
+			return nil, fmt.Errorf("Failed to save cert %s", err.Error())
+		}
+	} else {
+		key = appModel.Key
+		cert = appModel.Cert
+	}
+
+	certs = append(certs, portal.CertBundle{
+		Cert: cert,
+		Key:  key,
+	})
+
+	// send to portal
+	return certs, nil
+}
+
+func generate() (string, string, error) {
+	host := "localhost"
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", "", err
+	}
+
+	notBefore := time.Now()
+
+	notAfter := notBefore.Add(365 * 24 * 100 * time.Hour) // 100 years..
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return "", "", err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	template.DNSNames = append(template.DNSNames, host)
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return "", "", err
+	}
+
+	cert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	key := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+
+	return string(key), string(cert), err
+}

--- a/generators/router/routes.go
+++ b/generators/router/routes.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/nanobox-io/golang-portal-client"
-
 	"github.com/nanobox-io/nanobox-boxfile"
+
 	"github.com/nanobox-io/nanobox/models"
 )
 

--- a/models/app.go
+++ b/models/app.go
@@ -22,6 +22,10 @@ type App struct {
 	LocalIPs map[string]string
 	// the boxfile from the most recent deploy
 	DeployedBoxfile string
+	// the https key used
+	Key string
+	// the https cert used
+	Cert string
 }
 
 // IsNew returns true if the App hasn't been created yet
@@ -31,7 +35,6 @@ func (a *App) IsNew() bool {
 
 // Save persists the App to the database
 func (a *App) Save() error {
-
 	if err := put(a.EnvID, a.ID, a); err != nil {
 		return fmt.Errorf("failed to save app: %s", err.Error())
 	}

--- a/processors/platform/portal.go
+++ b/processors/platform/portal.go
@@ -21,10 +21,26 @@ func UpdatePortal(appModel *models.App) error {
 		return client.UpdateRoutes(routes)
 	}
 
+	// update cert
+	certs, err := generator.BuildCert(appModel)
+	if err != nil {
+		return util.ErrorAppend(err, "failed to build cert")
+	}
+
+	updateCert := func() error {
+		return client.UpdateCert(certs)
+	}
+
 	// use the retry method here because there is a chance the portal server isnt responding yet
 	if err := util.Retry(updateRoute, 2, time.Second); err != nil {
 		lumber.Error("platform:UpdatePortal:UpdateRoutes(%+v): %s", routes, err.Error())
 		return util.ErrorAppend(err, "failed to send routing updates to the router")
+	}
+
+	// use the retry method here because there is a chance the portal server isnt responding yet
+	if err := util.Retry(updateCert, 2, time.Second); err != nil {
+		lumber.Error("platform:UpdatePortal:UpdateCerts(%+v): %s", certs, err.Error())
+		return util.ErrorAppend(err, "failed to send cert updates to the router")
 	}
 
 	// update services


### PR DESCRIPTION
Must run `nanobox deploy dry-run`. Since there is no load balancer/router in front of the server when doing a `nanobox run`, https will still be unsupported.
A cert will be generated for each app, and will be re-used for that app (read: accept the cert once)

Resolves #278