### PR TITLE
Apparently the 'keys' hook also depends on the output

### DIFF
--- a/util/hookit/hookit.go
+++ b/util/hookit/hookit.go
@@ -41,7 +41,7 @@ func Exec(container, hook, payload, displayLevel string) (string, error) {
 	}
 
 	// the boxfile hook returns the boxfile, we shouldn't append anything.
-	if hook != "boxfile" {
+	if hook != "boxfile" && hook != "keys" {
 		if out == "" {
 			out = outs
 		} else if outs != "" {


### PR DESCRIPTION
My assumptions that the hook output was always ignored were wrong :disappointed:... I believe the last fix should have resolved this as well, but we'll explicitly list it for good measure.

Resolves #531