### PR TITLE
Support loading evars from files

### DIFF
--- a/commands/evar.go
+++ b/commands/evar.go
@@ -21,6 +21,7 @@ Manages environment variables in your different environments.
 //
 func init() {
 	EvarCmd.AddCommand(evar.AddCmd)
+	EvarCmd.AddCommand(evar.LoadCmd)
 	EvarCmd.AddCommand(evar.RemoveCmd)
 	EvarCmd.AddCommand(evar.ListCmd)
 }

--- a/commands/evar/add.go
+++ b/commands/evar/add.go
@@ -18,7 +18,7 @@ import (
 
 // AddCmd ...
 var AddCmd = &cobra.Command{
-	Use:   "add",
+	Use:   "add key=val[ key=val,key=val]",
 	Short: "Adds environment variable(s)",
 	Long:  ``,
 	// PreRun: steps.Run("login"),

--- a/commands/evar/evar_internal_test.go
+++ b/commands/evar/evar_internal_test.go
@@ -1,0 +1,53 @@
+package evar
+
+import (
+	"testing"
+)
+
+// TestEvarLoad tests the loading of environment variables from a file.
+func TestEvarLoad(t *testing.T) {
+	vars, _ := loadVars([]string{""}, testGetter{})
+	evars := parseSplitEvars(vars)
+
+	if len(evars) != 10 {
+		t.Fatalf("Failed to parse all evars - %d - %q", len(evars), evars)
+	}
+
+	if evars["KEY4"] != "\nanother\nmultiline\n" {
+		t.Fatalf("multiline var failed - %q", evars["KEY4"])
+	}
+	if evars["KEY5"] != "yes, even spaces and = are allowed as values" {
+		t.Fatalf("Commas, spaces, = var failed - %q", evars["KEY5"])
+	}
+	if evars["KEY9"] != "you're welcome ;)" {
+		t.Fatalf("Single quote, semicolon var failed - %q", evars["KEY9"])
+	}
+}
+
+type testGetter struct{}
+
+func (f testGetter) getContents(filename string) (string, error) {
+	return testContents, nil
+}
+
+var testContents = `
+key1=val
+key2="val"
+key3="this
+is
+a
+multiline
+value"
+key4="
+another
+multiline
+"
+key5="yes, even spaces and = are allowed as values"
+export key6=gasp
+export key7="how is this guy doing these awesome things"
+
+
+key8="yep, even whitespace is allowed (gets stripped)"
+export key9="you're welcome ;)"
+key10="x"
+`

--- a/commands/evar/load.go
+++ b/commands/evar/load.go
@@ -1,0 +1,95 @@
+package evar
+
+import (
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nanobox-io/nanobox/commands/steps"
+	"github.com/nanobox-io/nanobox/helpers"
+	"github.com/nanobox-io/nanobox/models"
+	app_evar "github.com/nanobox-io/nanobox/processors/app/evar"
+	production_evar "github.com/nanobox-io/nanobox/processors/evar"
+	"github.com/nanobox-io/nanobox/util"
+	"github.com/nanobox-io/nanobox/util/config"
+	"github.com/nanobox-io/nanobox/util/display"
+)
+
+// LoadCmd loads variables from a file.
+var LoadCmd = &cobra.Command{
+	Use:   "load filename",
+	Short: "Loads environment variable(s) from a file",
+	Long:  ``,
+	Run:   loadFn,
+}
+
+// loadFn parses a specified file and adds the contained variables to nanobox.
+// Read in the file, strip out 'export ', parse, add resulting vars
+func loadFn(ccmd *cobra.Command, args []string) {
+	// parse the evars excluding the context
+	env, _ := models.FindEnvByID(config.EnvID())
+	args, location, name := helpers.Endpoint(env, args, 0)
+	vars, err := loadVars(args)
+	if err != nil {
+		display.CommandErr(util.Err{
+			Message: err.Error(),
+			Code:    "USER",
+			Stack:   []string{"failed to load evars from file"},
+		})
+		return
+	}
+
+	evars := parseEvars(vars)
+
+	switch location {
+	case "local":
+		app, _ := models.FindAppBySlug(config.EnvID(), name)
+		display.CommandErr(app_evar.Add(env, app, evars))
+	case "production":
+		steps.Run("login")(ccmd, args)
+
+		production_evar.Add(env, name, evars)
+	}
+}
+
+// loadVars loads variables from filenames passed in
+func loadVars(args []string) ([]string, error) {
+	vars := []string{}
+
+	for _, filename := range args {
+		contents, err := ioutil.ReadFile(filename)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to read file - %s", err.Error())
+		}
+
+		// normalize file `key=val`
+		newthings := strings.Replace(string(contents), "export ", "", -1)
+
+		// strip out blank lines
+		newthings = regexp.MustCompilePOSIX(`\n\n+`).ReplaceAllString(newthings, "\n")
+
+		// strip trailing newline
+		newthings = regexp.MustCompilePOSIX(`\n$`).ReplaceAllString(newthings, "")
+
+		// get index of variable start (change regex to allow more than alphabet chars as keys)
+		indexes := regexp.MustCompilePOSIX(`(^[a-zA-Z]*?)=(\"\n|.)`).FindAllStringIndex(newthings, -1)
+
+		start := 0
+		for i := range indexes {
+			end := indexes[i][0]
+			if end == 0 {
+				continue
+			}
+			// end-1 leaves off the newline after the variable declaration
+			vars = append(vars, newthings[start:end-1])
+			start = end
+		}
+		// the newline after this variable declaration would have been previously stripped off
+		vars = append(vars, newthings[start:])
+	}
+
+	return vars, nil
+}

--- a/commands/run.go
+++ b/commands/run.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"

--- a/commands/run.go
+++ b/commands/run.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"

--- a/util/hookit/hookit.go
+++ b/util/hookit/hookit.go
@@ -31,10 +31,13 @@ func Exec(container, hook, payload, displayLevel string) (string, error) {
 	}
 
 	outs := stream.Output()
-	if out == "" {
-		out = outs
-	} else {
-		out = fmt.Sprintf("%s -- %s", out, outs)
+	// the boxfile hook returns the boxfile, we shouldn't append anything.
+	if hook != "boxfile" {
+		if out == "" {
+			out = outs
+		} else if outs != "" {
+			out = fmt.Sprintf("%s --- %s", out, outs)
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
`nanobox evar load local ./file1 ./file2 ./file3`

Accepted entries are as follows (obviously you'd have to have unique `key` values):

```
key=val
key="val"
key="this
is
a
multiline
value"
key="
another
multiline
"
key="yes, even spaces and = are allowed as values"
export key=gasp
export key="how is this guy doing these awesome things"


key="yep, even whitespace is allowed (gets stripped)"
export key="you're welcome ;)"
```
