### PR TITLE
Support setting custom tunnel port

### DIFF
--- a/commands/evar/list.go
+++ b/commands/evar/list.go
@@ -1,7 +1,9 @@
 package evar
 
 import (
-	// "fmt"
+	"strings"
+
+	"github.com/jcelliott/lumber"
 	"github.com/spf13/cobra"
 
 	"github.com/nanobox-io/nanobox/commands/steps"
@@ -15,11 +17,10 @@ import (
 
 // ListCmd ...
 var ListCmd = &cobra.Command{
-	Use:   "ls",
+	Use:   "ls [local|dry-run|remote-alias]",
 	Short: "list environment variable(s)",
 	Long:  ``,
-	// PreRun: steps.Run("login"),
-	Run: listFn,
+	Run:   listFn,
 }
 
 // listFn ...
@@ -27,6 +28,15 @@ func listFn(ccmd *cobra.Command, args []string) {
 
 	env, _ := models.FindEnvByID(config.EnvID())
 	args, location, name := helpers.Endpoint(env, args, 0)
+
+	// if the first argument is not a keyvalue pair, (at this point the
+	// remote-alias would be stripped from helpers.Endpoint) it is likely
+	// the app name. try setting vars on that app
+	if len(args) > 0 && !strings.Contains(args[0], "=") {
+		lumber.Info("Remote alias not found for '%s', attempting to set vars on app named '%s'\n", args[0], args[0])
+		name = args[0]
+		args = args[1:]
+	}
 
 	switch location {
 	case "local":

--- a/commands/evar/load.go
+++ b/commands/evar/load.go
@@ -20,10 +20,15 @@ import (
 
 // LoadCmd loads variables from a file.
 var LoadCmd = &cobra.Command{
-	Use:   "load filename",
+	Use:   "load [local|dry-run|remote-alias] filename",
 	Short: "Loads environment variable(s) from a file",
-	Long:  ``,
-	Run:   loadFn,
+	Long: `Loads environment variable(s) from a file.
+
+The alias must be used when loading variables for a production app.
+If you would like to load variables for a different app, please add
+it as a remote as follows: 'nanobox remote add <APPNAME> <ALIAS>'.
+You may then perform the 'load' again, specifying that alias.`,
+	Run: loadFn,
 }
 
 // loadFn parses a specified file and adds the contained variables to nanobox.

--- a/commands/evar/remove.go
+++ b/commands/evar/remove.go
@@ -17,10 +17,14 @@ import (
 
 // RemoveCmd removes an evar.
 var RemoveCmd = &cobra.Command{
-	Use:   "rm [local|dry-run] key",
+	Use:   "rm [local|dry-run|remote-alias] key",
 	Short: "Remove environment variable(s)",
-	Long:  ``,
-	// PreRun: steps.Run("login"),
+	Long: `Remove environment variable(s).
+
+The alias must be used when removing variables from a production app.
+If you would like to remove variables from a different app, please add
+it as a remote as follows: 'nanobox remote add <APPNAME> <ALIAS>'.
+You may then perform the 'rm' again, specifying that alias.`,
 	Run: removeFn,
 }
 
@@ -60,6 +64,8 @@ func parseKeys(args []string) []string {
 	keys := []string{}
 
 	for _, arg := range args {
+		// todo: remove support for comma separated key list (not necessary,
+		// but would be nice to have uniform syntax not supporting it)
 		for _, key := range strings.Split(arg, ",") {
 			keys = append(keys, strings.ToUpper(key))
 		}

--- a/commands/tunnel.go
+++ b/commands/tunnel.go
@@ -24,7 +24,7 @@ var (
 Creates a secure tunnel between your local machine &
 a live component. The tunnel allows you to manage
 live data using your local client of choice.
-		`,
+`,
 		PreRun: steps.Run("login"),
 		Run:    tunnelFn,
 	}
@@ -41,7 +41,7 @@ live data using your local client of choice.
 
 //
 func init() {
-	TunnelCmd.Flags().StringVarP(&portMap, "port", "p", "", "Local port to start listening on")
+	TunnelCmd.Flags().StringVarP(&portMap, "port", "p", "", "Specify a local[:destination] port to listen on and connect to.")
 }
 
 // tunnelFn validates the ports and establishes the tunnel

--- a/commands/tunnel.go
+++ b/commands/tunnel.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -17,7 +18,7 @@ import (
 var (
 	// TunnelCmd handles tunneling to components.
 	TunnelCmd = &cobra.Command{
-		Use:   "tunnel",
+		Use:   "tunnel [dry-run|remote-alias] component",
 		Short: "Create a secure tunnel between your local machine & a live component.",
 		Long: `
 Creates a secure tunnel between your local machine &
@@ -28,39 +29,23 @@ live data using your local client of choice.
 		Run:    tunnelFn,
 	}
 
-	// tunnelCmdFlags ...
-	tunnelCmdFlags = struct {
-		port string
+	// will contain either a listen port or a listen/destination port (chown style `8080:` would be 8080 for both)
+	portMap string
+
+	// tunnelPorts contains the ports used in the tunnel
+	tunnelPorts = struct {
+		listenPort int
+		destPort   int
 	}{}
 )
 
 //
 func init() {
-	TunnelCmd.Flags().StringVarP(&tunnelCmdFlags.port, "port", "p", "", "local port to start listening on")
+	TunnelCmd.Flags().StringVarP(&portMap, "port", "p", "", "Local port to start listening on")
 }
 
-// tunnelFn ...
+// tunnelFn validates the ports and establishes the tunnel
 func tunnelFn(ccmd *cobra.Command, args []string) {
-
-	if tunnelCmdFlags.port != "" {
-		port, err := strconv.Atoi(tunnelCmdFlags.port)
-		if err != nil {
-			fmt.Printf(`
-Please specify a number for a port to listen on. You specified '%s'.
-
-`, tunnelCmdFlags.port)
-			return
-		}
-
-		if port < 1024 {
-			fmt.Printf(`
-Please specify a number above 1023 as a port to listen on. You specified '%d'.
-
-`, port)
-			return
-		}
-	}
-
 	env, _ := models.FindEnvByID(config.EnvID())
 	args, location, name := helpers.Endpoint(env, args, 2)
 
@@ -68,14 +53,72 @@ Please specify a number above 1023 as a port to listen on. You specified '%d'.
 	// the required args this will return with instructions
 	if len(args) != 1 {
 		fmt.Printf(`
-Wrong number of arguments (expecting 1 got %v). Run the command again with the
-name of the container you would like to tunnel into:
+Wrong number of arguments (expecting 1 got %d). Run the command again with the
+name of the component you would like to tunnel into:
 
-ex: nanobox tunnel <container>
+ex: nanobox tunnel <component>
 
 `, len(args))
 
 		return
+	}
+
+	if portMap != "" {
+		ports := strings.Split(portMap, ":")
+		if len(ports) > 2 {
+			fmt.Printf(`
+Please specify a single port pair (source:dest). You specified '%s'.
+
+`, portMap)
+			return
+		}
+
+		// ports will always be length 1 if they put anything
+		port, err := strconv.Atoi(ports[0])
+		if err != nil {
+			fmt.Printf(`
+Please specify a number for a port to listen on. You specified '%s'.'%s'
+
+`, ports[0], err.Error())
+			return
+		}
+
+		// validate that it's not a priviledged listen port
+		if port < 1024 || port > 65535 {
+			fmt.Printf(`
+Please specify a number between 1024 and 65535 as a port to listen on. You specified '%d'.
+
+`, port)
+			return
+		}
+		tunnelPorts.listenPort = port
+
+		if len(ports) == 2 {
+			// heres the chown style 'fill in the blank' magic
+			if ports[1] == "" {
+				tunnelPorts.destPort = port
+			} else {
+				port, err := strconv.Atoi(ports[1])
+				if err != nil {
+					fmt.Printf(`
+Please specify a number for a port to tunnel to. You specified '%s'.
+
+`, ports[1])
+					return
+				}
+
+				// validate that it's a valid port
+				if port < 1 || port > 65535 {
+					fmt.Printf(`
+Please specify a number between 1 and 65535 as a destination port. You specified '%d'.
+
+`, port)
+					return
+				}
+				tunnelPorts.destPort = port
+
+			}
+		}
 	}
 
 	switch location {
@@ -84,10 +127,11 @@ ex: nanobox tunnel <container>
 		return
 	case "production":
 		// set the meta arguments to be used in the processor and run the processor
-		tunnelConfig := processors.TunnelConfig{
-			App:       name,
-			Port:      tunnelCmdFlags.port,
-			Container: args[0],
+		tunnelConfig := models.TunnelConfig{
+			AppName:    name,
+			ListenPort: tunnelPorts.listenPort,
+			DestPort:   tunnelPorts.destPort,
+			Component:  args[0],
 		}
 
 		display.CommandErr(processors.Tunnel(env, tunnelConfig))

--- a/commands/tunnel.go
+++ b/commands/tunnel.go
@@ -15,8 +15,7 @@ import (
 )
 
 var (
-
-	// TunnelCmd ...
+	// TunnelCmd handles tunneling to components.
 	TunnelCmd = &cobra.Command{
 		Use:   "tunnel",
 		Short: "Create a secure tunnel between your local machine & a live component.",

--- a/helpers/endpoint.go
+++ b/helpers/endpoint.go
@@ -25,5 +25,13 @@ func Endpoint(envModel *models.Env, args []string, maxArgs int) ([]string, strin
 		return args[1:], "production", args[0]
 	}
 
+	// todo: MAYBE check the remote here (`fetch the remote` in other locations in code)
+	// // fetch the remote
+	// remote, ok := envModel.Remotes[args[0]]
+	// if ok {
+	// 	// set the app id
+	//  return args[1:], "production", remote.ID
+	// }
+
 	return args, "production", "default"
 }

--- a/main.go
+++ b/main.go
@@ -44,8 +44,7 @@ func main() {
 
 	// if it is running the server just run it
 	// skip the tratiotional messaging
-	if len(os.Args) >= 2 && (
-		os.Args[1] == "server" ||
+	if len(os.Args) >= 2 && (os.Args[1] == "server" ||
 		os.Args[1] == "version" ||
 		os.Args[1] == "tunnel" ||
 		os.Args[1] == "console" ||

--- a/main.go
+++ b/main.go
@@ -44,7 +44,14 @@ func main() {
 
 	// if it is running the server just run it
 	// skip the tratiotional messaging
-	if len(os.Args) == 2 && (os.Args[1] == "server" || os.Args[1] == "version" || os.Args[1] == "tunnel" || os.Args[1] == "login" || os.Args[1] == "logout") {
+	if len(os.Args) >= 2 && (
+		os.Args[1] == "server" ||
+		os.Args[1] == "version" ||
+		os.Args[1] == "tunnel" ||
+		os.Args[1] == "console" ||
+		os.Args[1] == "log" ||
+		os.Args[1] == "login" ||
+		os.Args[1] == "logout") {
 		err := commands.NanoboxCmd.Execute()
 		if err != nil {
 			fmt.Println(err)

--- a/models/tunnel.go
+++ b/models/tunnel.go
@@ -1,0 +1,18 @@
+package models
+
+type (
+	// TunnelConfig contains the endpoint information.
+	TunnelConfig struct {
+		AppName    string // name of app to tunnel to
+		ListenPort int    // local port to listen on
+		DestPort   int    // port to tunnel to
+		Component  string // component to tunnel to
+	}
+
+	TunnelInfo struct {
+		Name  string `json:"name,omitempty"`  // component name being tunneled to
+		Token string `json:"token,omitempty"` // token to complete the tunnel
+		URL   string `json:"url,omitempty"`   // url/ip of nanoagent
+		Port  int    `json:"port"`            // port to tunnel to
+	}
+)

--- a/processors/console.go
+++ b/processors/console.go
@@ -1,6 +1,8 @@
 package processors
 
 import (
+	"strings"
+
 	"github.com/nanobox-io/nanobox/commands/registry"
 	"github.com/nanobox-io/nanobox/helpers"
 	"github.com/nanobox-io/nanobox/models"
@@ -46,7 +48,11 @@ func Console(envModel *models.Env, consoleConfig ConsoleConfig) error {
 		err = util.ErrorAppend(err, "failed to initiate a remote console session")
 		if err != nil {
 			if err2, ok := err.(util.Err); ok {
-				err2.Suggest = "It appears there is no component/host by that name, check the component/host name and try again"
+				if strings.Contains(err2.Error(), "Internal Server Error") {
+					err2.Suggest = "It appears there was an issue with the request. If subsequent attempts fail, please report."
+				} else {
+					err2.Suggest = "It appears there is no component/host by that name, check the component/host name and try again"
+				}
 				return err2
 			}
 		}

--- a/processors/deploy.go
+++ b/processors/deploy.go
@@ -18,7 +18,7 @@ func Deploy(envModel *models.Env, deployConfig DeployConfig) error {
 	appID := deployConfig.App
 
 	// fetch the remote
-	remote, ok := envModel.Remotes[deployConfig.App]
+	remote, ok := envModel.Remotes[appID]
 	if ok {
 		// set the odin endpoint
 		odin.SetEndpoint(remote.Endpoint)

--- a/processors/evar/add.go
+++ b/processors/evar/add.go
@@ -3,6 +3,7 @@ package evar
 import (
 	"fmt"
 
+	"github.com/nanobox-io/nanobox/commands/registry"
 	"github.com/nanobox-io/nanobox/models"
 	"github.com/nanobox-io/nanobox/util/display"
 	"github.com/nanobox-io/nanobox/util/odin"
@@ -17,6 +18,11 @@ func Add(envModel *models.Env, appID string, evars map[string]string) error {
 		odin.SetEndpoint(remote.Endpoint)
 		// set the app id
 		appID = remote.ID
+	}
+
+	// set odins endpoint if the arguement is passed
+	if endpoint := registry.GetString("endpoint"); endpoint != "" {
+		odin.SetEndpoint(endpoint)
 	}
 
 	// iterate through the evars and add them to the app

--- a/processors/evar/list.go
+++ b/processors/evar/list.go
@@ -3,6 +3,7 @@ package evar
 import (
 	"fmt"
 
+	"github.com/nanobox-io/nanobox/commands/registry"
 	"github.com/nanobox-io/nanobox/models"
 	"github.com/nanobox-io/nanobox/util/odin"
 )
@@ -15,6 +16,11 @@ func List(envModel *models.Env, appID string) error {
 		odin.SetEndpoint(remote.Endpoint)
 		// set the app id
 		appID = remote.ID
+	}
+
+	// set odins endpoint if the arguement is passed
+	if endpoint := registry.GetString("endpoint"); endpoint != "" {
+		odin.SetEndpoint(endpoint)
 	}
 
 	evars, err := odin.ListEvars(appID)

--- a/processors/evar/remove.go
+++ b/processors/evar/remove.go
@@ -3,6 +3,7 @@ package evar
 import (
 	"fmt"
 
+	"github.com/nanobox-io/nanobox/commands/registry"
 	"github.com/nanobox-io/nanobox/models"
 	"github.com/nanobox-io/nanobox/util/display"
 	"github.com/nanobox-io/nanobox/util/odin"
@@ -17,6 +18,11 @@ func Remove(envModel *models.Env, appID string, keys []string) error {
 		odin.SetEndpoint(remote.Endpoint)
 		// set the app id
 		appID = remote.ID
+	}
+
+	// set odins endpoint if the arguement is passed
+	if endpoint := registry.GetString("endpoint"); endpoint != "" {
+		odin.SetEndpoint(endpoint)
 	}
 
 	evars, err := odin.ListEvars(appID)

--- a/processors/log/log.go
+++ b/processors/log/log.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nanopack/mist/core"
 	"golang.org/x/net/websocket"
 
+	"github.com/nanobox-io/nanobox/commands/registry"
 	"github.com/nanobox-io/nanobox/helpers"
 	"github.com/nanobox-io/nanobox/models"
 	"github.com/nanobox-io/nanobox/util"
@@ -37,6 +38,11 @@ func Tail(envModel *models.Env, app string, logFollow bool) error {
 		odin.SetEndpoint(remote.Endpoint)
 		// set the app id
 		appID = remote.ID
+	}
+
+	// set odins endpoint if the arguement is passed
+	if endpoint := registry.GetString("endpoint"); endpoint != "" {
+		odin.SetEndpoint(endpoint)
 	}
 
 	// todo: don't assume app name, just message and die
@@ -76,6 +82,11 @@ func Print(envModel *models.Env, app string, numLogs int) error {
 		odin.SetEndpoint(remote.Endpoint)
 		// set the app id
 		appID = remote.ID
+	}
+
+	// set odins endpoint if the arguement is passed
+	if endpoint := registry.GetString("endpoint"); endpoint != "" {
+		odin.SetEndpoint(endpoint)
 	}
 
 	// todo: don't assume app name, just message and die
@@ -243,7 +254,10 @@ func fetchLogs(token, url string, numLogs int) error {
 	msgs := []logvac.Message{}
 	err = json.Unmarshal(body, &msgs)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal - %s", err.Error())
+		return util.Err{
+			Message: fmt.Sprintf("Failed to process historic logs - %s", err.Error()),
+			Suggest: "Please upgrade your logging component and try again.",
+		}
 	}
 
 	for i := range msgs {

--- a/processors/tunnel.go
+++ b/processors/tunnel.go
@@ -19,7 +19,7 @@ func Tunnel(envModel *models.Env, tunnelConfig models.TunnelConfig) error {
 		// set the odin endpoint
 		odin.SetEndpoint(remote.Endpoint)
 		// set the app id
-		tunnelConfig.AppName = remote.ID
+		tunnelConfig.AppName = remote.Name
 	}
 
 	// set the app id to the directory name if it's default
@@ -40,7 +40,6 @@ func Tunnel(envModel *models.Env, tunnelConfig models.TunnelConfig) error {
 	// initiate a tunnel session with odin
 	tunInfo, err := odin.EstablishTunnel(tunnelConfig)
 	if err != nil {
-		// todo: can we know if the request was rejected for authorization and print that?
 		return util.ErrorAppend(err, "failed to initiate a remote tunnel session")
 	}
 

--- a/processors/tunnel.go
+++ b/processors/tunnel.go
@@ -12,17 +12,19 @@ import (
 	"github.com/nanobox-io/nanobox/util/odin"
 )
 
-func Tunnel(envModel *models.Env, tunnelConfig TunnelConfig) error {
-
-	appID := tunnelConfig.App
-
+func Tunnel(envModel *models.Env, tunnelConfig models.TunnelConfig) error {
 	// fetch the remote
-	remote, ok := envModel.Remotes[appID]
+	remote, ok := envModel.Remotes[tunnelConfig.AppName]
 	if ok {
 		// set the odin endpoint
 		odin.SetEndpoint(remote.Endpoint)
 		// set the app id
-		appID = remote.ID
+		tunnelConfig.AppName = remote.ID
+	}
+
+	// set the app id to the directory name if it's default
+	if tunnelConfig.AppName == "default" {
+		tunnelConfig.AppName = config.AppName()
 	}
 
 	// set odins endpoint if the arguement is passed
@@ -30,30 +32,25 @@ func Tunnel(envModel *models.Env, tunnelConfig TunnelConfig) error {
 		odin.SetEndpoint(endpoint)
 	}
 
-	// set the app id to the directory name if it's default
-	if appID == "default" {
-		appID = config.AppName()
-	}
-
 	// validate access to the app
-	if err := helpers.ValidateOdinApp(appID); err != nil {
+	if err := helpers.ValidateOdinApp(tunnelConfig.AppName); err != nil {
 		return util.ErrorAppend(err, "unable to validate app")
 	}
 
 	// initiate a tunnel session with odin
-	key, location, port, err := odin.EstablishTunnel(appID, tunnelConfig.Container)
+	tunInfo, err := odin.EstablishTunnel(tunnelConfig)
 	if err != nil {
 		// todo: can we know if the request was rejected for authorization and print that?
 		return util.ErrorAppend(err, "failed to initiate a remote tunnel session")
 	}
 
 	// set a default port if the user didn't specify
-	if tunnelConfig.Port == "" {
-		tunnelConfig.Port = fmt.Sprintf("%d", port)
+	if tunnelConfig.ListenPort == 0 {
+		tunnelConfig.ListenPort = tunInfo.Port
 	}
 
 	// connect up to the session
-	if err := nanoagent.Tunnel(key, location, tunnelConfig.Port, tunnelConfig.Container); err != nil {
+	if err := nanoagent.Tunnel(tunInfo.Token, tunInfo.URL, fmt.Sprint(tunnelConfig.ListenPort), tunnelConfig.Component); err != nil {
 		return util.ErrorAppend(err, "failed to connect to remote tunnel session")
 	}
 

--- a/processors/types.go
+++ b/processors/types.go
@@ -10,9 +10,3 @@ type ConsoleConfig struct {
 	App  string
 	Host string
 }
-
-type TunnelConfig struct {
-	App       string
-	Port      string
-	Container string
-}

--- a/util/display/logs.go
+++ b/util/display/logs.go
@@ -41,7 +41,7 @@ func FormatLogMessage(msg mist.Message) {
 	// unmarshal the message data as an Entry
 	entry := Entry{}
 	if err := json.Unmarshal([]byte(msg.Data), &entry); err != nil {
-		message := fmt.Sprintf("[light_red]%s :: %s\n[reset]%s", time.Now().Format(layout), msg.Data, fmt.Sprintf("Failed to process entry - '%s'. Consider running `nanobox update-images` and re-trying.", err.Error()))
+		message := fmt.Sprintf("[light_red]%s :: %s\n[reset]%s", time.Now().Format(layout), msg.Data, fmt.Sprintf("Failed to process entry - '%s'. Please upgrade your logging component and try again.", err.Error()))
 		fmt.Println(colorstring.Color(message))
 		return
 	}

--- a/util/nanoagent/tunnel.go
+++ b/util/nanoagent/tunnel.go
@@ -13,6 +13,10 @@ import (
 )
 
 func Tunnel(key, location, port, name string) error {
+	if port == "0" {
+		return fmt.Errorf("port 0 is not a valid port - that component has nothing to tunnel to")
+	}
+
 	// establish a connection and just leave it open.
 	req, err := http.NewRequest("POST", fmt.Sprintf("/tunnel?key=%s", key), nil)
 	if err != nil {


### PR DESCRIPTION
Usage examples:
```
# tunnel to database on the default port, listening locally on port 8080
nanobox tunnel myapp data.db -p 8080

# tunnel to database on port 5432, listening locally on port 8080
nanobox tunnel myapp data.db -p 8080:5432

# tunnel to database on port 8080, listening locally on port 8080
nanobox tunnel myapp data.db -p 8080:
```


Resolves #496 