### PR TITLE
Allow option to not strip timestamps from original logs

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -123,6 +123,7 @@ func init() {
 	NanoboxCmd.PersistentFlags().BoolVarP(&displayTraceMode, "trace", "t", false, "Increases display output and sets level to trace")
 
 	// log specific flags
+	LogCmd.Flags().BoolVarP(&logRaw, "raw", "r", false, "Print raw log timestamps instead")
 	LogCmd.Flags().BoolVarP(&logFollow, "follow", "f", false, "Follow logs (live feed)")
 	LogCmd.Flags().IntVarP(&logNumber, "number", "n", 0, "Number of historic logs to print")
 	// todo:

--- a/commands/log.go
+++ b/commands/log.go
@@ -17,6 +17,7 @@ import (
 var (
 	logFollow bool
 	logNumber int
+	logRaw    bool   // display log timestamps instead of added ones
 	logStart  string // todo: forthcoming
 	logEnd    string // todo: forthcoming
 	logLimit  string // todo: forthcoming
@@ -53,11 +54,16 @@ logs inside a terminal running 'nanobox run'.
 		display.CommandErr(platform.MistListen(app))
 	case "production":
 		steps.Run("login")(ccmd, args)
+		logOpts := models.LogOpts{
+			Number: logNumber,
+			Follow: logFollow,
+			Raw:    logRaw,
+		}
 
 		// since we default to live logging, if `-n` is set, we'll print that many
 		// historic logs and return unless `-f` is also set.
 		if logNumber > 0 {
-			display.CommandErr(log.Print(envModel, name, logNumber))
+			display.CommandErr(log.Print(envModel, name, logOpts))
 
 			// if `-f` is also specified, continue, else return here.
 			if !logFollow {
@@ -66,6 +72,6 @@ logs inside a terminal running 'nanobox run'.
 		}
 
 		// set the meta arguments to be used in the processor and run the processor
-		display.CommandErr(log.Tail(envModel, name, logFollow))
+		display.CommandErr(log.Tail(envModel, name, logOpts))
 	}
 }

--- a/models/log.go
+++ b/models/log.go
@@ -1,0 +1,11 @@
+package models
+
+// LogOpts are options for logging
+type LogOpts struct {
+	Follow bool   // Follow is whether or not to follow the log stream.
+	Number int    // Number of logs to print.
+	Raw    bool   // Raw will not strip out the timestamp from the log stream.
+	Start  string // Start is where to start the logs from.
+	End    string // End is where to end the logs.
+	Limit  string // Limit is how many logs to show.
+}

--- a/processors/platform/mist.go
+++ b/processors/platform/mist.go
@@ -53,7 +53,7 @@ waiting for output...
 	for {
 		select {
 		case msg := <-client.Messages():
-			display.FormatLogMessage(msg)
+			display.FormatLogMessage(msg, false)
 		case <-sigChan:
 			return nil
 		}

--- a/util/display/logs.go
+++ b/util/display/logs.go
@@ -63,7 +63,7 @@ func FormatLogMessage(msg mist.Message, showTimestamp bool) {
 	// return our pretty entry
 	var message string
 	if showTimestamp {
-		message = fmt.Sprintf("[%s]%s %s (%s) :: %s[reset]", logProcesses[entryTag], fmt.Sprintf(entry.Time.Format(layout)), entry.ID, entryTag, entry.Message)
+		message = fmt.Sprintf("[%s]%s (%s) :: %s[reset]", logProcesses[entryTag], entry.ID, entryTag, entry.Message)
 	} else {
 		message = fmt.Sprintf("[%s]%s %s (%s) :: %s[reset]", logProcesses[entryTag], fmt.Sprintf(entry.Time.Format(layout)), entry.ID, entryTag, fmtMsg)
 	}
@@ -105,7 +105,7 @@ func FormatLogvacMessage(msg logvac.Message, showTimestamp bool) {
 	// return our pretty entry
 	var message string
 	if showTimestamp {
-		message = fmt.Sprintf("[%s]%s %s (%s) :: %s[reset]", logProcesses[entryTag], fmt.Sprintf(entry.Time.Format(layout)), entry.ID, entryTag, entry.Message)
+		message = fmt.Sprintf("[%s]%s (%s) :: %s[reset]", logProcesses[entryTag], entry.ID, entryTag, entry.Message)
 	} else {
 		message = fmt.Sprintf("[%s]%s %s (%s) :: %s[reset]", logProcesses[entryTag], fmt.Sprintf(entry.Time.Format(layout)), entry.ID, entryTag, fmtMsg)
 	}

--- a/util/display/logs.go
+++ b/util/display/logs.go
@@ -33,7 +33,7 @@ var (
 
 // FormatLogMessage takes a Logvac/Mist and formats it into a pretty message to be
 // output to the terminal
-func FormatLogMessage(msg mist.Message) {
+func FormatLogMessage(msg mist.Message, showTimestamp bool) {
 
 	// set the time output format
 	layout := "Mon Jan 02 15:04:05 2006" // time.RFC822
@@ -61,14 +61,19 @@ func FormatLogMessage(msg mist.Message) {
 	}
 
 	// return our pretty entry
-	message := fmt.Sprintf("[%s]%s %s (%s) :: %s[reset]", logProcesses[entryTag], fmt.Sprintf(entry.Time.Format(layout)), entry.ID, entryTag, fmtMsg)
+	var message string
+	if showTimestamp {
+		message = fmt.Sprintf("[%s]%s %s (%s) :: %s[reset]", logProcesses[entryTag], fmt.Sprintf(entry.Time.Format(layout)), entry.ID, entryTag, entry.Message)
+	} else {
+		message = fmt.Sprintf("[%s]%s %s (%s) :: %s[reset]", logProcesses[entryTag], fmt.Sprintf(entry.Time.Format(layout)), entry.ID, entryTag, fmtMsg)
+	}
 	fmt.Println(colorstring.Color(message))
 	return
 }
 
 // FormatLogvacMessage takes a Logvac/Mist and formats it into a pretty message to be
 // output to the terminal
-func FormatLogvacMessage(msg logvac.Message) {
+func FormatLogvacMessage(msg logvac.Message, showTimestamp bool) {
 
 	// set the time output format
 	layout := "Mon Jan 02 15:04:05 2006" // time.RFC822
@@ -98,7 +103,13 @@ func FormatLogvacMessage(msg logvac.Message) {
 	}
 
 	// return our pretty entry
-	message := fmt.Sprintf("[%s]%s %s (%s) :: %s[reset]", logProcesses[entryTag], fmt.Sprintf(entry.Time.Format(layout)), entry.ID, entryTag, fmtMsg)
+	var message string
+	if showTimestamp {
+		message = fmt.Sprintf("[%s]%s %s (%s) :: %s[reset]", logProcesses[entryTag], fmt.Sprintf(entry.Time.Format(layout)), entry.ID, entryTag, entry.Message)
+	} else {
+		message = fmt.Sprintf("[%s]%s %s (%s) :: %s[reset]", logProcesses[entryTag], fmt.Sprintf(entry.Time.Format(layout)), entry.ID, entryTag, fmtMsg)
+	}
+
 	fmt.Println(colorstring.Color(message))
 	return
 }


### PR DESCRIPTION
Resolves #559 
~~- [ ] strip runit timestamps~~
- [x] don't print leading timestamp (only print one (if app logs it)) in --raw mode