### PR TITLE
Refactor local engine configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 2.3.1 (unreleased)
+
+FEATURES:
+  - Add dns alias' to run and dry-run containers [#592](https://github.com/nanobox-io/nanobox/pull/592)
+  - Support service configuration enhancements [#586](https://github.com/nanobox-io/nanobox/pull/586)
+  - Support password protected ssh keys [#576](https://github.com/nanobox-io/nanobox/pull/576)[#580](https://github.com/nanobox-io/nanobox/pull/580)[#582](https://github.com/nanobox-io/nanobox/pull/582)
+  - Untrack vendored files [#567](https://github.com/nanobox-io/nanobox/pull/567)
+
+BUG FIXES:
+  - Refactor local engine configuration [#604](https://github.com/nanobox-io/nanobox/pull/604)
+  - Fix panic on linux if nfs isn't running [#601](https://github.com/nanobox-io/nanobox/pull/601)
+  - Handle `nanobox-update` not being in global path [#596](https://github.com/nanobox-io/nanobox/pull/596)
+  - Fix fast notify watcher warning typos [#594](https://github.com/nanobox-io/nanobox/pull/594)
+  - Update `--help` docs for cli [#593](https://github.com/nanobox-io/nanobox/pull/593)[#598](https://github.com/nanobox-io/nanobox/pull/598)
+  - Only pull `nanobox/*` images on `update-images` [#591](https://github.com/nanobox-io/nanobox/pull/591)
+  - Only add valid, un-password protected ssh keys [#572](https://github.com/nanobox-io/nanobox/pull/572)
+  - Fix regression and allow multiple apps on osx [#571](https://github.com/nanobox-io/nanobox/pull/571)
+  - Fix broken route for email login [hotfix](d9469af105be39d402e5e6ad6312f3a9ecf95f6f)
+
+
 ## 2.3.0 (Sept 1, 2017)
 
 FEATURES:

--- a/generators/containers/build.go
+++ b/generators/containers/build.go
@@ -14,12 +14,16 @@ import (
 func BuildConfig(image string) docker.ContainerConfig {
 	env := config.EnvID()
 	code := fmt.Sprintf("%s%s/code:/app", provider.HostShareDir(), env)
+	// mounting from b2d "global zone" to container will be the same whether local engine specified or not
 	engine := fmt.Sprintf("%s%s/engine:/share/engine", provider.HostShareDir(), env)
 
 	if !provider.RequiresMount() {
 		code = fmt.Sprintf("%s:/app", config.LocalDir())
-		if config.EngineDir() != "" {
-			engine = fmt.Sprintf("%s:/share/engine", config.EngineDir())
+
+		// todo: test this (likely docker-native linux)
+		engineDir, _ := config.EngineDir()
+		if engineDir != "" {
+			engine = fmt.Sprintf("%s:/share/engine", engineDir)
 		}
 	}
 
@@ -50,10 +54,6 @@ func BuildConfig(image string) docker.ContainerConfig {
 
 	// set http[s]_proxy and no_proxy vars
 	setProxyVars(&conf)
-
-	if config.EngineDir() != "" {
-		conf.Binds = append(conf.Binds, engine)
-	}
 
 	return conf
 }

--- a/generators/containers/compile.go
+++ b/generators/containers/compile.go
@@ -18,8 +18,9 @@ func CompileConfig(image string) docker.ContainerConfig {
 
 	if !provider.RequiresMount() {
 		code = fmt.Sprintf("%s:/share/code", config.LocalDir())
-		if config.EngineDir() != "" {
-			engine = fmt.Sprintf("%s:/share/engine", config.EngineDir())
+		engineDir, _ := config.EngineDir()
+		if engineDir != "" {
+			engine = fmt.Sprintf("%s:/share/engine", engineDir)
 		}
 	}
 
@@ -50,10 +51,6 @@ func CompileConfig(image string) docker.ContainerConfig {
 
 	// set http[s]_proxy and no_proxy vars
 	setProxyVars(&conf)
-
-	if config.EngineDir() != "" {
-		conf.Binds = append(conf.Binds, engine)
-	}
 
 	return conf
 }

--- a/util/display/messages.go
+++ b/util/display/messages.go
@@ -357,3 +357,14 @@ local web/worker, please use 'nanobox run'.
 --------------------------------------------------------------------------------
 `))
 }
+
+func LocalEngineNotFound() {
+	os.Stderr.WriteString(fmt.Sprintf(`
+--------------------------------------------------------------------------------
+LOCAL ENGINE NOT FOUND
+It appears the local engine sepcified does not exist at the location defined.
+Please double check your boxfile.yml and the path to the engine. If the path
+you specified exists, please contact support.
+--------------------------------------------------------------------------------
+`))
+}

--- a/util/provider/share/share_linux.go
+++ b/util/provider/share/share_linux.go
@@ -109,7 +109,6 @@ func (sh *ShareRPC) Add(req Request, resp *Response) error {
 
 // Remove will remove an nfs share
 func Remove(path string) error {
-
 	// generate the entry
 	entry, err := entry(path)
 	if err != nil {


### PR DESCRIPTION
Turns out when we renamed boxfile nodes, we never updated nanobox to
match. This addresses that and properly mounts in a specified local
engine as well as cleans up the mount should a user stop using the local
engine.

Resolves #603