### PR TITLE
Add version output to update

### DIFF
--- a/util/update/run.go
+++ b/util/update/run.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/nanobox-io/nanobox/util/display"
@@ -24,6 +25,7 @@ func Run(path string) error {
 		return err
 	}
 
+	fmt.Printf("Current version: %s", getCurrentVersion(path))
 	// download the file and display the progress bar
 	resp, err := http.Get(remotePath())
 	if err != nil {
@@ -49,5 +51,19 @@ func Run(path string) error {
 	// update the model
 	update := newUpdate()
 
+	fmt.Printf("Updated to version: %s", getCurrentVersion(path))
+
 	return update.Save()
+}
+
+func getCurrentVersion(path string) string {
+	if path == "" {
+		fmt.Errorf("invalid path")
+	}
+	version, err := exec.Command(path, "version").Output()
+	if err != nil {
+		fmt.Errorf("Error while trying to get the nanobox version")
+		return ""
+	}
+	return string(version)
 }

--- a/util/update/run.go
+++ b/util/update/run.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/nanobox-io/nanobox/util/display"
 )
@@ -53,6 +54,8 @@ func Run(path string) error {
 
 	fmt.Printf("Updated to version: %s", getCurrentVersion(path))
 
+	printGithubReleaseUrl(getCurrentVersion(path))
+
 	return update.Save()
 }
 
@@ -66,4 +69,10 @@ func getCurrentVersion(path string) string {
 		return ""
 	}
 	return string(version)
+}
+
+func printGithubReleaseUrl(version string) {
+	semver := strings.Split(strings.Split(version, " ")[2], "-")[0]
+	fmt.Printf("Check out the release notes here: \n")
+	fmt.Printf("https://github.com/nanobox-io/nanobox/releases/tag/%s \n", semver)
 }

--- a/util/update/run.go
+++ b/util/update/run.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/nanobox-io/nanobox/util/display"
 )
@@ -52,11 +51,9 @@ func Run(path string) error {
 	// update the model
 	update := newUpdate()
 
-	newVersion := getCurrentVersion(path)
-
-	fmt.Printf("Updated to version: %s", newVersion)
-
-	printGithubReleaseUrl(newVersion)
+	fmt.Printf("\nUpdated to version: %s\n\n", getCurrentVersion(path))
+	fmt.Println("Check out the release notes here:")
+	fmt.Println("https://github.com/nanobox-io/nanobox/blob/master/CHANGELOG.md")
 
 	return update.Save()
 }
@@ -73,8 +70,3 @@ func getCurrentVersion(path string) string {
 	return string(version)
 }
 
-func printGithubReleaseUrl(version string) {
-	semver := strings.Split(strings.Split(version, " ")[2], "-")[0]
-	fmt.Printf("Check out the release notes here: \n")
-	fmt.Printf("https://github.com/nanobox-io/nanobox/releases/tag/%s \n", semver)
-}

--- a/util/update/run.go
+++ b/util/update/run.go
@@ -52,9 +52,11 @@ func Run(path string) error {
 	// update the model
 	update := newUpdate()
 
-	fmt.Printf("Updated to version: %s", getCurrentVersion(path))
+	newVersion := getCurrentVersion(path)
 
-	printGithubReleaseUrl(getCurrentVersion(path))
+	fmt.Printf("Updated to version: %s", newVersion)
+
+	printGithubReleaseUrl(newVersion)
 
 	return update.Save()
 }


### PR DESCRIPTION
It ends up looking like this:
```
Current version: Nanobox Version 0.0.0-now (custom)

   9.81/9.81MB [****************************************  100.00%]
Updated to version: Nanobox Version 2.3.0-171025T0249 (28ee681)
```
^ above output is from me replacing my current nanobox binary with a locally built one and updating.
I tried to use `models.VersionString()`, but since it is a different binary, it doesn't have access to the correct version in the registry and just has the default of `0.0.0`. This is a bit of a hack, but it does use the nanobox binary to find the version. 