### PR TITLE
HOTFIX: Fix server start

### DIFF
--- a/commands/server/svc_unix.go
+++ b/commands/server/svc_unix.go
@@ -2,8 +2,6 @@
 
 package server
 
-import ()
-
 func svcStart() {
-
+	return
 }

--- a/models/version.go
+++ b/models/version.go
@@ -3,7 +3,7 @@ package models
 import "fmt"
 
 var (
-	// will be set with build flags, defaults for one-off `go-build`
+	// will be set with build flags, defaults for one-off `go build`
 	nanoVersion string = "0.0.0"  // git tag
 	nanoCommit  string = "custom" // commit id of build
 	nanoBuild   string = "now"    // date of build

--- a/updater/main.go
+++ b/updater/main.go
@@ -12,13 +12,20 @@ import (
 	"github.com/nanobox-io/nanobox/util/update"
 )
 
+// nanobox-update's version
+var VERSION = "0.8.0" // todo: maybe we'll ldflag populate this too
+
 // main ...
 func main() {
-
 	path := ""
 	var err error
+
 	// this will write a new binary at location provided `nanobox-update newbinary`
 	if len(os.Args) > 1 {
+		if os.Args[1] == "version" {
+			fmt.Printf("nanobox-update %s\n", VERSION)
+			return
+		}
 		path = os.Args[1]
 	} else {
 		// get the location of the current nanobox

--- a/util/update/run.go
+++ b/util/update/run.go
@@ -69,4 +69,3 @@ func getCurrentVersion(path string) string {
 	}
 	return string(version)
 }
-

--- a/util/update/run.go
+++ b/util/update/run.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/nanobox-io/nanobox/util/display"
 )
@@ -15,7 +16,7 @@ var Server bool
 
 func Run(path string) error {
 	if path == "" {
-		fmt.Errorf("invalid path")
+		return fmt.Errorf("invalid path")
 	}
 
 	// create a temporary file
@@ -25,7 +26,10 @@ func Run(path string) error {
 		return err
 	}
 
-	fmt.Printf("Current version: %s", getCurrentVersion(path))
+	if !strings.Contains(path, "nanobox-update") {
+		fmt.Printf("Current version: %s", getCurrentVersion(path))
+	}
+
 	// download the file and display the progress bar
 	resp, err := http.Get(remotePath())
 	if err != nil {
@@ -51,20 +55,23 @@ func Run(path string) error {
 	// update the model
 	update := newUpdate()
 
-	fmt.Printf("\nUpdated to version: %s\n\n", getCurrentVersion(path))
-	fmt.Println("Check out the release notes here:")
-	fmt.Println("https://github.com/nanobox-io/nanobox/blob/master/CHANGELOG.md")
+	if !strings.Contains(path, "nanobox-update") {
+		fmt.Printf("\nUpdated to version: %s\n\n", getCurrentVersion(path))
+		fmt.Println("Check out the release notes here:")
+		fmt.Println("https://github.com/nanobox-io/nanobox/blob/master/CHANGELOG.md")
+	}
 
 	return update.Save()
 }
 
 func getCurrentVersion(path string) string {
 	if path == "" {
-		fmt.Errorf("invalid path")
+		fmt.Println("invalid path")
+		return ""
 	}
 	version, err := exec.Command(path, "version").Output()
 	if err != nil {
-		fmt.Errorf("Error while trying to get the nanobox version")
+		fmt.Println("Error while trying to get the nanobox version")
 		return ""
 	}
 	return string(version)


### PR DESCRIPTION
In order to get the version, we were running the `"path" version`, which
when called with `nanobox-update version`, downloads the latest nanobox
to the file `version`. Service managers don't like this. This commit
should fix that and allow nanobox to start up again.