### PR TITLE
Add 'cache clear' command to clear package cache

### DIFF
--- a/commands/cache.go
+++ b/commands/cache.go
@@ -1,0 +1,69 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nanobox-io/nanobox/commands/steps"
+	"github.com/nanobox-io/nanobox/models"
+	"github.com/nanobox-io/nanobox/processors/cache"
+	"github.com/nanobox-io/nanobox/util/display"
+)
+
+func init() {
+	CacheCmd.AddCommand(clearCmd)
+}
+
+var (
+	// CacheCmd provides interaction with the package cache.
+	CacheCmd = &cobra.Command{
+		Use:   "cache",
+		Short: "Manage the package cache.",
+	}
+
+	// clearCmd allows clearing the cache
+	clearCmd = &cobra.Command{
+		Use:   "clear [app-name]",
+		Short: "Clear the package cache.",
+		Long: `
+The 'app-name' comes from the directory name, or 'nanobox status'.
+Not specifying an app name will clear every app's pkg cache.
+`,
+		PreRun: steps.Run("start"),
+		Run:    clearFn,
+	}
+)
+
+func clearFn(ccmd *cobra.Command, args []string) {
+	if len(args) > 0 {
+		env, err := models.FindEnvByName(args[0])
+		if env == nil {
+			fmt.Printf("Failed to search apps: %s\n", err.Error())
+			return
+		}
+		if err == nil {
+			err = cache.Clear(env.ID)
+			if err != nil {
+				display.CommandErr(err)
+				return
+			}
+
+			fmt.Printf("Cleared package cache for '%s'.\n", env.ID)
+			return
+		}
+	}
+
+	envs, err := models.AllEnvs()
+	if err != nil {
+		fmt.Printf("Failed listing apps: %s\n", err.Error())
+		return
+	}
+
+	err = cache.ClearAll(envs)
+	if err != nil {
+		display.CommandErr(err)
+		return
+	}
+	fmt.Println("Cleared all app package caches.")
+}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -155,6 +155,7 @@ func init() {
 	NanoboxCmd.AddCommand(DnsCmd)
 	NanoboxCmd.AddCommand(LogCmd)
 	NanoboxCmd.AddCommand(VersionCmd)
+	NanoboxCmd.AddCommand(CacheCmd)
 	NanoboxCmd.AddCommand(server.ServerCmd)
 
 	// hidden subcommands

--- a/models/env.go
+++ b/models/env.go
@@ -91,6 +91,23 @@ func FindEnvByID(ID string) (*Env, error) {
 	return env, nil
 }
 
+// FindEnvByName finds an app by a name
+func FindEnvByName(name string) (*Env, error) {
+	apps := []*Env{}
+
+	if err := getAll("envs", &apps); err != nil {
+		return nil, fmt.Errorf("failed to get all envs: %s", err.Error())
+	}
+
+	for i := range apps {
+		if apps[i].Name == name {
+			return apps[i], nil
+		}
+	}
+
+	return &Env{}, fmt.Errorf("failed to find env '%s' by name", name)
+}
+
 // AllEnvs loads all of the Envs in the database
 func AllEnvs() ([]*Env, error) {
 	// list of apps to return

--- a/processors/cache/cache.go
+++ b/processors/cache/cache.go
@@ -1,0 +1,32 @@
+// Package cache contains logic for managing the cache volume.
+package cache
+
+import (
+	"fmt"
+
+	"github.com/nanobox-io/golang-docker-client"
+
+	"github.com/nanobox-io/nanobox/models"
+)
+
+// ClearAll will clear all cache volumes for the app environments passed in.
+func ClearAll(envs []*models.Env) error {
+	for i := range envs {
+		err := docker.VolumeRemove(fmt.Sprintf("nanobox_%s_cache", envs[i].ID))
+		if err != nil {
+			return fmt.Errorf("Failed to remove volume - %s", err.Error())
+		}
+	}
+
+	return nil
+}
+
+// Clear will clear the cache volume for the app id passed in.
+func Clear(id string) error {
+	err := docker.VolumeRemove(fmt.Sprintf("nanobox_%s_cache", id))
+	if err != nil {
+		return fmt.Errorf("Failed to remove volume - %s", err.Error())
+	}
+
+	return nil
+}


### PR DESCRIPTION
This command makes it easier to clear the package cache in instances
where it may contain corrupt or bad packages. It doesn't require
destroying or altering any other part of the app. It does require
nanobox to be running, but will start it if it is not.