### PR TITLE
Add `--clear-cache` flag to clear package cache from hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ GO_LDFLAGS="-s -X github.com/nanobox-io/nanobox/util/odin.apiKey=$(API_KEY) -X g
 
 default: build
 
+local: linux windows darwin
+
 clean:
 	@echo "Cleaning old builds"
 	@rm -rf "./.build"

--- a/commands/build.go
+++ b/commands/build.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/nanobox-io/nanobox/commands/steps"
+	"github.com/nanobox-io/nanobox/generators/hooks/build"
 	"github.com/nanobox-io/nanobox/models"
 	"github.com/nanobox-io/nanobox/processors"
 	"github.com/nanobox-io/nanobox/util"
@@ -13,8 +14,7 @@ import (
 )
 
 var (
-
-	// BuildCmd ...
+	// BuildCmd builds the app's runtime.
 	BuildCmd = &cobra.Command{
 		Use:   "build-runtime",
 		Short: "Build your app's runtime.",
@@ -26,20 +26,26 @@ locally and in live environments.
 		Run:     buildFn,
 		Aliases: []string{"build"},
 	}
+
+	cacheClear bool
 )
 
 func init() {
 	steps.Build("build-runtime", buildComplete, buildFn)
+
+	BuildCmd.Flags().BoolVar(&cacheClear, "clear-cache", false, "Clear package cache for this build.")
 }
 
-// buildFn ...
 func buildFn(ccmd *cobra.Command, args []string) {
+	if cacheClear {
+		build.ClearPkgCache = true
+	}
+
 	env, _ := models.FindEnvByID(config.EnvID())
 	display.CommandErr(processors.Build(env))
 }
 
-// todo: this doesn't seem to ever run, find out when it does
-// update: this seems to run on deploy
+// update: this runs on deploy
 func buildComplete() bool {
 	// check the boxfile to be sure it hasnt changed
 	env, _ := models.FindEnvByID(config.EnvID())

--- a/commands/steps/run.go
+++ b/commands/steps/run.go
@@ -1,19 +1,18 @@
 package steps
 
 import (
-	"github.com/nanobox-io/nanobox/commands/registry"
-	// "github.com/nanobox-io/nanobox/util/display"
 	"github.com/spf13/cobra"
+
+	"github.com/nanobox-io/nanobox/commands/registry"
 )
 
 func Run(stepNames ...string) func(ccmd *cobra.Command, args []string) {
-	//
 	return func(ccmd *cobra.Command, args []string) {
 
 		if registry.GetBool("internal") {
 			return
 		}
-		//
+
 		for _, stepName := range stepNames {
 			step, ok := stepList[stepName]
 			if ok && !step.complete() {

--- a/generators/hooks/build/pack_build.go
+++ b/generators/hooks/build/pack_build.go
@@ -1,7 +1,18 @@
 package build
 
+import (
+	"encoding/json"
+)
+
 // PackBuildPayload returns a string for the user hook payload
 func PackBuildPayload() string {
+	if ClearPkgCache {
+		rtn := map[string]string{}
+		rtn["clear_cache"] = "true"
+		bytes, _ := json.Marshal(rtn)
+		return string(bytes)
+	}
+
 	// currently, this payload is empty. This may change at some point
 	return emptyPayload()
 }

--- a/generators/hooks/build/setup.go
+++ b/generators/hooks/build/setup.go
@@ -1,7 +1,19 @@
 package build
 
+import (
+	"encoding/json"
+)
+
+var ClearPkgCache bool
+
 // SetupPayload returns a string for the user hook payload
 func SetupPayload() string {
+	if ClearPkgCache {
+		rtn := map[string]string{}
+		rtn["clear_cache"] = "true"
+		bytes, _ := json.Marshal(rtn)
+		return string(bytes)
+	}
 	// currently, this payload is empty. This may change at some point
 	return emptyPayload()
 }

--- a/util/config/dirs.go
+++ b/util/config/dirs.go
@@ -145,6 +145,7 @@ func EngineDir() (string, error) {
 // BinDir creates a directory where nanobox specific binaries can be downloaded
 // docker, dockermachine, etc
 func BinDir() string {
+	// todo: maybe replace with `os.Executable()`
 	path, err := exec.LookPath(os.Args[0])
 	if err != nil {
 		if runtime.GOOS == "windows" {

--- a/util/config/vars.go
+++ b/util/config/vars.go
@@ -39,10 +39,13 @@ func EnvID() string {
 // NanoboxPath ...
 func NanoboxPath() string {
 
-	programName := os.Args[0]
+	programName, err := os.Executable()
+	if err == nil {
+		return programName
+	}
 
 	// lookup the full path to nanobox
-	path, err := exec.LookPath(programName)
+	path, err := exec.LookPath(os.Args[0])
 	if err == nil {
 		return path
 	}

--- a/util/service/start_unix.go
+++ b/util/service/start_unix.go
@@ -15,6 +15,7 @@ func Start(name string) error {
 	}
 
 	if !Running(name) {
+		fmt.Printf("%s\n", out)
 		return fmt.Errorf("%s service start was successful but the service is not running", name)
 	}
 	return nil


### PR DESCRIPTION
This flag makes it easier to clear the package cache in instances
where it may contain corrupt or bad packages. It doesn't require
destroying or altering any other part of the app. It only requires the
new image or to use pre-merge:

```
run.config:
  image: nanobox/build:feature_release-2017-11
```