### PR TITLE
Issue a warning about .dev TLDs

### DIFF
--- a/processors/app/dns/add.go
+++ b/processors/app/dns/add.go
@@ -39,6 +39,16 @@ func Add(envModel *models.Env, appModel *models.App, name string) error {
 		return util.ErrorAppend(err, "failed to setup server")
 	}
 
+	// issue a warning about `.dev` being unusable with Chrome
+	if name[len(name)-4:] == ".dev" {
+		tld := appModel.DisplayName()
+		if tld == "dry-run" {
+			tld = "test"
+		}
+
+		display.Warn("\nGoogle has been locking down use of the .dev TLD, and your app may not be accessible with this domain.\nTry using %s.%s instead\n", name[0:len(name)-4], tld)
+	}
+
 	// add the entry
 	if err := dns.Add(entry); err != nil {
 		lumber.Error("dns:Add:dns.Add(%s): %s", entry, err.Error())

--- a/processors/app/dns/add.go
+++ b/processors/app/dns/add.go
@@ -46,7 +46,7 @@ func Add(envModel *models.Env, appModel *models.App, name string) error {
 			tld = "test"
 		}
 
-		display.Warn("\nGoogle has been locking down use of the .dev TLD, and your app may not be accessible with this domain.\nTry using %s.%s instead\n", name[0:len(name)-4], tld)
+		return util.Errorf("Google has been locking down use of the .dev TLD, and your app may not be accessible with this domain.\nTry using %s.%s instead.", name[0:len(name)-4], tld)
 	}
 
 	// add the entry


### PR DESCRIPTION
Google is cracking down. Warn users about `.dev` not working, and recommend `.local` for dev, and `.test` for dry-run, instead.