### PR TITLE
Disable cgo so binary will run on alpine

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+# disable cgo for true static binaries (will work on alpine linux)
+export CGO_ENABLED=0;
+
 # vfor versioning
 getCurrCommit() {
   echo `git rev-parse --short HEAD | tr -d "[ \r\n\']"`


### PR DESCRIPTION
Currently running `nanobox` on alpine linux will return `./nanobox not found`. This is related to [this issue](https://github.com/gliderlabs/docker-alpine/issues/78). A workaround until this is merged is to link the appropriate so that the binary is looking for:

```
mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
```