### PR TITLE
Fix typo in info command

### DIFF
--- a/commands/info.go
+++ b/commands/info.go
@@ -39,7 +39,7 @@ func infoFn(ccmd *cobra.Command, args []string) {
 	case "production":
 		fmt.Printf(`
 ----------------------------------------------------------
-Showing production app information is not yet implemneted.
+Showing production app information is not yet implemented.
 ----------------------------------------------------------
 
 `)


### PR DESCRIPTION
# Fix typo in info command
When running the `nanobox info` command it currently says that
running the command against production is not yet implemented.
In that sentence "implemented" was incorrectly spelled "implemneted".

Issue: https://github.com/nanobox-io/nanobox/issues/664