### PR TITLE
Support mid-value equal sign in evar loading

### DIFF
--- a/commands/evar/evar_internal_test.go
+++ b/commands/evar/evar_internal_test.go
@@ -35,7 +35,7 @@ func TestEvarLoad(t *testing.T) {
 	vars, _ := loadVars([]string{""}, testGetter{})
 	evars := parseEvars(vars)
 
-	if len(evars) != 11 {
+	if len(evars) != 13 {
 		t.Fatalf("Failed to parse all evars - %d - %q", len(evars), evars)
 	}
 
@@ -53,6 +53,14 @@ func TestEvarLoad(t *testing.T) {
 
 	if evars["KEY_11"] != "x\ny\nz" {
 		t.Fatalf("Underscored key failed - %q", evars["KEY_11"])
+	}
+
+	if evars["KEY_12"] != "this\none\nhas\nan=in\nthe\nmiddle" {
+		t.Fatalf("Multiline var with equal sign in value failed to parse - %q should be \"this\none\nhas\nan=in\nthe\nmiddle\"", evars["KEY_12"])
+	}
+
+	if evars["KEY_13"] != "previous value with equal sign isn't greedy and leaves me alone" {
+		t.Fatalf("Variable(s) after one with equal sign in middle failed to parse - %q should be \"previous value with equal sign isn't greedy and leaves me alone\"", evars["KEY_13"])
 	}
 }
 
@@ -87,4 +95,11 @@ key10="x"
 key_11="x
 y
 z"
+key_12="this
+one
+has
+an=in
+the
+middle"
+key_13="previous value with equal sign isn't greedy and leaves me alone"
 `

--- a/commands/evar/evar_internal_test.go
+++ b/commands/evar/evar_internal_test.go
@@ -35,7 +35,7 @@ func TestEvarLoad(t *testing.T) {
 	vars, _ := loadVars([]string{""}, testGetter{})
 	evars := parseEvars(vars)
 
-	if len(evars) != 13 {
+	if len(evars) != 15 {
 		t.Fatalf("Failed to parse all evars - %d - %q", len(evars), evars)
 	}
 
@@ -61,6 +61,14 @@ func TestEvarLoad(t *testing.T) {
 
 	if evars["KEY_13"] != "previous value with equal sign isn't greedy and leaves me alone" {
 		t.Fatalf("Variable(s) after one with equal sign in middle failed to parse - %q should be \"previous value with equal sign isn't greedy and leaves me alone\"", evars["KEY_13"])
+	}
+
+	if evars["KEY_14"] != "this line isn't the end\\\"\nthis=one is" {
+		t.Fatalf("Variable with equal sign and escaped quote failed to parse - %q should be \"this line isn't the end\\\"\nthis=one is\"", evars["KEY_14"])
+	}
+
+	if evars["KEY_15"] != "previous value with escaped quoted isn't greedy and leaves me alone" {
+		t.Fatalf("Variable(s) after one with escaped quote failed to parse - %q should be \"previous value with escaped quoted isn't greedy and leaves me alone\"", evars["KEY_15"])
 	}
 }
 
@@ -102,4 +110,7 @@ an=in
 the
 middle"
 key_13="previous value with equal sign isn't greedy and leaves me alone"
+key_14="this line isn't the end\"
+this=one is"
+key_15="previous value with escaped quoted isn't greedy and leaves me alone"
 `

--- a/commands/evar/load.go
+++ b/commands/evar/load.go
@@ -91,6 +91,18 @@ func loadVars(args []string, getter contentGetter) ([]string, error) {
 			if end <= 2 {
 				continue
 			}
+
+			if regexp.MustCompilePOSIX(`(^[a-zA-Z0-9_]*?)="(\n|.)`).MatchString(newthings[start:end-1]) {
+				// Now we know that this variable is enclosed in quotes
+				if newthings[end-2:end-1] != "\"" {
+					// Now we know that this block begins a variable but does not complete it,
+					// there may be an equal sign in the middle that was evaluated as the start
+					// of a new variable - continue so that the next variable becomes a part of
+					// this variable and re-evaluate that the new block ends with quotes correctly
+					continue
+				}
+			}
+
 			// end-1 leaves off the newline after the variable declaration
 			vars = append(vars, newthings[start:end-1])
 			start = end

--- a/commands/evar/load.go
+++ b/commands/evar/load.go
@@ -94,7 +94,7 @@ func loadVars(args []string, getter contentGetter) ([]string, error) {
 
 			if regexp.MustCompilePOSIX(`(^[a-zA-Z0-9_]*?)="(\n|.)`).MatchString(newthings[start:end-1]) {
 				// Now we know that this variable is enclosed in quotes
-				if newthings[end-2:end-1] != "\"" {
+				if newthings[end-2:end-1] != "\"" || newthings[end-3:end-1] == "\\\"" {
 					// Now we know that this block begins a variable but does not complete it,
 					// there may be an equal sign in the middle that was evaluated as the start
 					// of a new variable - continue so that the next variable becomes a part of


### PR DESCRIPTION
Fixes an issue where an equal sign in the body of a multi-line environmental variable surrounded by quotes would be interpretted as the beginning of a new variable instead of just a part of the current variable. Now when a quoted variable body is found that doesn’t end in a quote, subsequent variables will be added to the body of the current variable until the closing quote is found. This prevents accidental breaking-up of multi-line variable bodies due to equal signs.

Pardon my verbose comments - this was the first Go I've ever written and just wrote my intentions down so I wouldn't lose track of my logic while I was busy looking up syntax and functions.

Relates to issue #668 