### PR TITLE
add NANOBOX envr for application switches

### DIFF
--- a/generators/hooks/build/dev.go
+++ b/generators/hooks/build/dev.go
@@ -8,9 +8,13 @@ import (
 )
 
 func DevPayload(appModel *models.App) string {
-	// create an APP_IP evar
 	evars := appModel.Evars
+
+	// create an APP_IP evar
 	evars["APP_IP"] = appModel.LocalIPs["env"]
+
+	// create a NANOBOX evar
+	evars["NANOBOX"] = "nanobox"
 
 	rtn := map[string]interface{}{}
 	rtn["env"] = evars


### PR DESCRIPTION
Currently you can not know if the application is run within a nanobox or not, by the environmental values.
This PR adds an environmental value names `NANOBOX` so the applications can, for example, recognize this and switch settings with it.

e.g.
```elixir
# inside config/dev.exs
if System.get_env("NANOBOX") do
  IO.puts "*** Overwriting with Nanobox-specific settings."
  import_config "dev.nanobox.exs"
end
```